### PR TITLE
Add philosophy conflict detector, philosopher ensemble, ensemble CLI, and API contract v0.1

### DIFF
--- a/aicw/__init__.py
+++ b/aicw/__init__.py
@@ -1,6 +1,7 @@
 from .decision import build_decision_report, format_report
 from .schema import DECISION_REQUEST_V0, DECISION_BRIEF_V0, validate_request
 from .context_compress import compress_situation
+from .philosophy_check import detect_philosophy_conflicts
 
 __all__ = [
     "build_decision_report",
@@ -9,4 +10,5 @@ __all__ = [
     "DECISION_BRIEF_V0",
     "validate_request",
     "compress_situation",
+    "detect_philosophy_conflicts",
 ]

--- a/aicw/decision.py
+++ b/aicw/decision.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Tuple
 
 from .safety import guard_text, scan_manipulation
+from .philosophy_check import detect_philosophy_conflicts
 
 
 # ---------------------------------------------------------------------------
@@ -494,6 +495,12 @@ def build_decision_report(request: Dict[str, Any]) -> Dict[str, Any]:
         rec_id = "A"
         explanation += f" 影響スコア({impact_score}): 生存構造への影響が複数層に渡るため A（安全側）に引き上げ。"
         reason_codes = reason_codes + ["EXISTENCE_IMPACT_OVERRIDE"]
+
+    # Task8接続: 哲学的矛盾検知を selection.reason_codes に反映
+    philo_text = f"{situation} {explanation}"
+    for code in detect_philosophy_conflicts(philo_text):
+        if code not in reason_codes:
+            reason_codes.append(code)
 
     candidates = [
         {"id": cid, "summary": options[i], "not_selected_reason_code": (

--- a/aicw/philosophy_check.py
+++ b/aicw/philosophy_check.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import re
+from typing import List
+
+# 理由コード（P2 Task 8）
+DUTY_OUTCOME_CONFLICT = "PHILO_DUTY_OUTCOME_CONFLICT"
+FAIRNESS_EFFICIENCY_CONFLICT = "PHILO_FAIRNESS_EFFICIENCY_CONFLICT"
+RIGHTS_TOTAL_BENEFIT_CONFLICT = "PHILO_RIGHTS_TOTAL_BENEFIT_CONFLICT"
+
+
+# 逆接があると「同一説明内での緊張関係」が強いとみなす
+_CONTRAST_RX = re.compile(r"(だが|しかし|一方で|ただし|though|however|but)", re.IGNORECASE)
+
+# 義務論（ルール・権利）
+_DUTY_TERMS = (
+    "義務", "規則", "ルール", "禁止", "権利", "尊厳", "守るべき", "絶対",
+)
+# 功利（総便益・効率）
+_OUTCOME_TERMS = (
+    "効用", "便益", "最大化", "最適化", "効率", "成果", "生産性", "多数",
+)
+# 公正（公平・差別回避）
+_FAIRNESS_TERMS = (
+    "公平", "公正", "平等", "差別", "偏り", "バイアス", "機会均等",
+)
+
+# 合理化のための少数犠牲・例外許容を示す語
+_EXCEPTION_TERMS = (
+    "例外", "一部犠牲", "多少の犠牲", "切り捨て", "優先", "容認",
+)
+
+
+def _contains_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(t in text for t in terms)
+
+
+def detect_philosophy_conflicts(text: str) -> List[str]:
+    """説明文から哲学的な緊張・矛盾パターンを検知し、理由コードを返す。"""
+    if not text:
+        return []
+
+    codes: List[str] = []
+    has_contrast = bool(_CONTRAST_RX.search(text))
+
+    has_duty = _contains_any(text, _DUTY_TERMS)
+    has_outcome = _contains_any(text, _OUTCOME_TERMS)
+    has_fairness = _contains_any(text, _FAIRNESS_TERMS)
+    has_exception = _contains_any(text, _EXCEPTION_TERMS)
+
+    # 1) 義務論 vs 功利
+    if has_duty and has_outcome and (has_contrast or has_exception):
+        codes.append(DUTY_OUTCOME_CONFLICT)
+
+    # 2) 公正 vs 効率
+    if has_fairness and has_outcome and (has_contrast or has_exception):
+        codes.append(FAIRNESS_EFFICIENCY_CONFLICT)
+
+    # 3) 権利 vs 総便益（多数利益のための権利侵害）
+    if has_duty and has_outcome and ("多数" in text or "全体" in text) and has_exception:
+        codes.append(RIGHTS_TOTAL_BENEFIT_CONFLICT)
+
+    return codes

--- a/aicw/schema.py
+++ b/aicw/schema.py
@@ -166,6 +166,10 @@ DECISION_BRIEF_V0: Dict[str, Any] = {
             "EXISTENCE_RISK_MEDIUM":    "生存構造への影響に注意（ライフサイクルと破壊の両方を検知）",
             "EXISTENCE_LIFECYCLE_OK":   "自然なライフサイクルの範囲内と判定",
             "EXISTENCE_IMPACT_OVERRIDE":"影響スコアが高く推奨を A（安全側）に引き上げ（P3）",
+            # 哲学的矛盾検知（Task8接続）
+            "PHILO_DUTY_OUTCOME_CONFLICT": "義務・権利と成果最大化が同時に主張され、緊張がある",
+            "PHILO_FAIRNESS_EFFICIENCY_CONFLICT": "公平・公正と効率最適化が衝突している",
+            "PHILO_RIGHTS_TOTAL_BENEFIT_CONFLICT": "全体便益のために権利例外を許容する緊張がある",
         },
         "not_selected": {
             "N/A":                "この案が推奨",

--- a/bridge/ensemble.py
+++ b/bridge/ensemble.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+_STANCES = ("support", "oppose", "hold")
+
+
+def _contains_any(text: str, keywords: List[str]) -> bool:
+    return any(k in text for k in keywords)
+
+
+def _hiroshi_opinion(prompt: str) -> Dict[str, str]:
+    if _contains_any(prompt, ["問い", "存在", "倫理"]):
+        return {
+            "name": "HiroshiTanaka",
+            "stance": "hold",
+            "rationale": "問いの正当性と存在構造の確認が先行し、拙速な断定を避ける。",
+        }
+    return {
+        "name": "HiroshiTanaka",
+        "stance": "hold",
+        "rationale": "世界の緊張を保持し、段階的に判断する。",
+    }
+
+
+def _pragmatist_opinion(prompt: str) -> Dict[str, str]:
+    if _contains_any(prompt, ["検証", "段階", "小さく", "試験"]):
+        return {
+            "name": "Pragmatist",
+            "stance": "support",
+            "rationale": "検証可能で段階実行できるため、限定導入を支持する。",
+        }
+    return {
+        "name": "Pragmatist",
+        "stance": "hold",
+        "rationale": "実行計画が未確定のため、条件整備まで保留する。",
+    }
+
+
+def _rights_guardian_opinion(prompt: str) -> Dict[str, str]:
+    risk_keywords = ["個人情報", "監視", "操作", "扇動", "差別", "破壊", "支配"]
+    if _contains_any(prompt, risk_keywords):
+        return {
+            "name": "RightsGuardian",
+            "stance": "oppose",
+            "rationale": "権利侵害・被害集中のリスクがあるため反対する。",
+        }
+    return {
+        "name": "RightsGuardian",
+        "stance": "support",
+        "rationale": "重大な権利侵害シグナルが薄く、安全条件付きで支持可能。",
+    }
+
+
+def run_ensemble(prompt: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """軽量の哲学者アンサンブル。多数派と少数意見を返す。"""
+    _ = context or {}
+    opinions = [
+        _hiroshi_opinion(prompt),
+        _pragmatist_opinion(prompt),
+        _rights_guardian_opinion(prompt),
+    ]
+
+    counts = Counter(op["stance"] for op in opinions if op["stance"] in _STANCES)
+    majority_stance = counts.most_common(1)[0][0] if counts else "hold"
+
+    majority_members = [op["name"] for op in opinions if op["stance"] == majority_stance]
+    minority = [op for op in opinions if op["stance"] != majority_stance]
+
+    if not minority:
+        minority = [
+            {
+                "name": "SystemMinority",
+                "stance": "hold",
+                "rationale": "全会一致のため、監査目的で保留の少数意見を補完生成。",
+            }
+        ]
+
+    return {
+        "opinions": opinions,
+        "majority": {
+            "stance": majority_stance,
+            "members": majority_members,
+            "count": len(majority_members),
+        },
+        "minority_report": minority,
+    }

--- a/docs/api_contract_v0_1.md
+++ b/docs/api_contract_v0_1.md
@@ -1,0 +1,76 @@
+# API Contract v0.1
+
+本ドキュメントは、`AI-Can-we-create-AI-` の現行 CLI / スキーマに基づく
+**固定契約（v0.1）**を定義する。
+
+## 1. Request Contract (`decision_request.v0`)
+
+`aicw/schema.py` の `DECISION_REQUEST_V0` を正とする。
+
+### 必須キー
+- `situation: str`
+
+### 任意キー
+- `constraints: list[str]`
+- `options: list[str]`
+- `asker_status: str`
+- `beneficiaries: list[str]`
+- `affected_structures: list[str]`
+
+### 追加制約
+- 不明キーはバリデーションエラー。
+- 型不一致はバリデーションエラー。
+
+---
+
+## 2. Response Contract (`decision_brief.v0`)
+
+`aicw/schema.py` の `DECISION_BRIEF_V0` を正とする。
+
+### 共通
+- `status: "ok" | "blocked"`
+
+### `status == "ok"` 時に必須
+- `meta`
+- `input`
+- `candidates`
+- `selection`
+- `counterarguments`
+- `uncertainties`
+- `externalities`
+- `next_questions`
+- `existence_analysis`
+- `impact_map`
+- `disclaimer`
+
+### `status == "blocked"` 時に必須
+- `blocked_by`
+- `reason`
+- `detected`
+- `safe_alternatives`
+
+### `blocked_by` の許容値
+- `#6 Privacy`
+- `#5 Existence Ethics`
+- `#4 Manipulation`
+
+---
+
+## 3. CLI Contract (`scripts/brief.py`)
+
+実行形式:
+- `python scripts/brief.py request.json`
+- `echo '{...}' | python scripts/brief.py`
+
+終了コード:
+- `0`: 正常終了（`status == ok`）
+- `1`: blocked（`status == blocked`）
+- `2`: 引数エラー / JSONパースエラー
+
+---
+
+## 4. Versioning Policy
+
+- `v0.1` の契約変更は **破壊的変更** とみなし、
+  `docs/api_contract_v0_1.md` と `tests/test_api_contract.py` を同時更新する。
+- スキーマ/CLI実装と契約テストが一致しない場合は、実装を修正してからマージする。

--- a/guideline.md
+++ b/guideline.md
@@ -180,4 +180,9 @@ python run_demo.py
 - [x] Week1 P1: 文化差分テスト + 事後検証テンプレ + 文脈圧縮
 - [x] Week2 Task6: manipulation動的化（スコアリング + 閾値昇格）
 - [x] Week2 Task7: 不確実性マップ（Mermaid風テキスト）
-- [ ] Week2 P1/P2: manipulation動的化 + 不確実性マップ + 哲学モジュール + API契約固定
+- [x] Week2 Task10: Po_core 統合インターフェース v0.1 固定（API契約 + 契約テスト）
+- [x] Week2 Task9: 哲学者アンサンブル（軽量）
+- [x] Week2 Task8: 哲学的矛盾検知モジュール（reason code返却）
+- [x] Task8 接続: 哲学的矛盾検知（PHILO_*）を decision.selection.reason_codes に統合
+- [x] three_review に Ensemble（多数派/少数意見）セクションを統合
+- [x] scripts/ensemble_review.py を追加（Ensemble 単体CLI + blocked分岐）

--- a/progress_log.md
+++ b/progress_log.md
@@ -1,6 +1,152 @@
 # Progress Log
 > 各セッションの最後に追記（可能なら日付はJST、形式はYYYY-MM-DD）
 
+## 2026-03-09 (session 16 — Ensemble Review CLI 追加)
+
+### Goal
+- Task9 の実運用導線として、ensemble を単体実行できる CLI を追加する
+
+### Done
+- `scripts/ensemble_review.py`（新規）:
+  - 入力: request JSON（stdin/ファイル）
+  - `build_decision_report` で blocked 判定を先に実施
+  - ok 時は `run_ensemble(prompt)` を実行し、majority/minority/all opinions を Markdown 風で出力
+  - blocked 時は理由と safe_alternatives を出力して exit code 1
+  - exit code 0/1/2（ok / blocked / invalid）
+- `tests/test_ensemble_review_cli.py`（新規）: 4件追加
+  - ok 時の exit 0
+  - 出力に Majority/Minority を含む
+  - blocked 時の exit 1 + BLOCKED 表示
+  - 不正JSONで exit 2
+- `guideline.md`:
+  - Current Next Actions に CLI 追加完了を追記
+
+### Test Results
+- `python -m unittest -v tests.test_ensemble_review_cli` PASS
+- `python -m unittest discover -s tests -v` PASS
+
+---
+
+## 2026-03-09 (session 15 — three_review に Ensemble セクション統合)
+
+### Goal
+- 既存の Task9（bridge/ensemble.py）を three_review CLI 出力に接続し、多視点レビューを実際に利用可能にする
+
+### Done
+- `scripts/three_review.py`:
+  - `run_ensemble` を取り込み、`build_ensemble_section(report)` を追加
+  - `format_three_review()` に `🧠 Ensemble（多視点レビュー）` セクションを追加
+  - 多数派（stance/members）と少数意見（minority report）を表示
+- `tests/test_p1_features.py`:
+  - `TestThreeReviewEnsemble` を追加（2件）
+    - Ensemble セクションが出力に含まれる
+    - 多数派・minority report 文言が含まれる
+- `guideline.md`:
+  - Current Next Actions に統合作業の完了を追記
+
+### Test Results
+- `python -m unittest -v tests.test_p1_features` PASS
+- `python -m unittest discover -s tests -v` PASS
+
+---
+
+## 2026-03-09 (session 14 — Task8統合: PHILO reason_codes を Decision Brief に接続)
+
+### Goal
+- 追加済みの哲学矛盾検知モジュールを `build_decision_report()` に統合し、実出力で利用可能にする
+
+### Done
+- `aicw/decision.py`:
+  - `detect_philosophy_conflicts` を import
+  - `selection.explanation` 生成後に `situation + explanation` を検査し、`PHILO_*` を `selection.reason_codes` へ追記
+  - 重複コードは追加しないように制御
+- `aicw/schema.py`:
+  - `reason_codes.selection` に `PHILO_DUTY_OUTCOME_CONFLICT` / `PHILO_FAIRNESS_EFFICIENCY_CONFLICT` /
+    `PHILO_RIGHTS_TOTAL_BENEFIT_CONFLICT` を追加
+- `tests/test_philosophy_check.py`:
+  - integration test を追加（`build_decision_report` 経由で `PHILO_DUTY_OUTCOME_CONFLICT` が反映されることを確認）
+- `guideline.md`:
+  - Current Next Actions に Task8統合完了を追記
+
+### Test Results
+- `python -m unittest -v tests.test_philosophy_check` PASS
+- `python -m unittest discover -s tests -v` PASS
+
+---
+
+## 2026-03-09 (session 13 — Task 10: API契約 v0.1 固定)
+
+### Goal
+- Week2 Task10（P2）: 現行 schema/CLI を基準に API 契約書を固定し、逸脱検知テストを追加する
+
+### Done
+- `docs/api_contract_v0_1.md`（新規）:
+  - request/response/CLI の固定契約（必須キー・enum・exit code）を明文化
+  - `blocked_by` の許容値（#6/#5/#4）を明記
+  - 変更時は契約書と契約テストを同時更新する運用を明記
+- `tests/test_api_contract.py`（新規）: 9件追加
+  - request契約（必須・allowed・未知キー拒否）
+  - response契約（status enum / blocked_by_values）
+  - 実行時契約（ok/blocked の必須キー）
+  - CLI契約（exit code 0/1/2）
+- `guideline.md`:
+  - Sprint Plan進捗に Week2 Task10 完了を反映
+
+### Test Results
+- `python -m unittest -v tests.test_api_contract` PASS
+- `python -m unittest discover -s tests -v` PASS
+
+---
+
+## 2026-03-09 (session 12 — Task 9: 哲学者アンサンブル)
+
+### Goal
+- Week2 Task9（P2）: bridge 層で軽量な哲学者アンサンブルを実装し、多数派と少数意見を返す
+
+### Done
+- `bridge/ensemble.py`（新規）:
+  - `run_ensemble(prompt, context=None)` を追加
+  - 3哲学者テンプレート（HiroshiTanaka / Pragmatist / RightsGuardian）で意見生成
+  - 出力: `opinions` / `majority` / `minority_report`
+  - 全会一致時でも `SystemMinority` を補完して少数意見を常に返す
+- `tests/test_ensemble.py`（新規）: 5件追加
+  - 必須キー、3テンプレート、majority構造、minority常時出力、リスク文脈で oppose を検証
+- `guideline.md`:
+  - Sprint Plan進捗に Week2 Task9 完了を反映
+
+### Test Results
+- `python -m unittest -v tests.test_ensemble` PASS
+- `python -m unittest discover -s tests -v` PASS
+
+---
+
+
+## 2026-03-09 (session 11 — Task 8: 哲学的矛盾検知モジュール)
+
+### Goal
+- Week2 Task8（P2）: 説明文中の規範矛盾を簡易ルールで検知し、reason code を返す
+
+### Done
+- `aicw/philosophy_check.py`（新規）:
+  - `detect_philosophy_conflicts(text)` を追加
+  - 3系統の矛盾パターンを reason code で返却
+    - `PHILO_DUTY_OUTCOME_CONFLICT`（義務論 vs 功利）
+    - `PHILO_FAIRNESS_EFFICIENCY_CONFLICT`（公正 vs 効率）
+    - `PHILO_RIGHTS_TOTAL_BENEFIT_CONFLICT`（権利 vs 総便益）
+  - 逆接（だが/しかし/一方で）と例外語を組み合わせた軽量判定
+- `tests/test_philosophy_check.py`（新規）: 5件追加
+  - 空入力 / 3系統の検知 / 非検知ケース
+- `aicw/__init__.py`:
+  - `detect_philosophy_conflicts` を公開APIに追加
+- `guideline.md`:
+  - Sprint Plan進捗に Week2 Task8 完了を反映
+
+### Test Results
+- `python -m unittest -v tests.test_philosophy_check` PASS
+- `python -m unittest discover -s tests -v` PASS
+
+---
+
 ## 2026-02-28 (session 9 — 整理 + Markdown アダプタ + bridge テスト)
 
 ### Goal

--- a/scripts/ensemble_review.py
+++ b/scripts/ensemble_review.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Ensemble Review CLI
+
+Usage:
+  python scripts/ensemble_review.py request.json
+  echo '{"situation":"..."}' | python scripts/ensemble_review.py
+
+Exit codes:
+  0: ok
+  1: blocked
+  2: invalid args/json
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, List
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from aicw.decision import build_decision_report
+from bridge.ensemble import run_ensemble
+
+
+def _read_input(args: List[str]) -> str:
+    if not args:
+        return sys.stdin.read()
+    if len(args) == 1:
+        try:
+            with open(args[0], encoding="utf-8") as f:
+                return f.read()
+        except OSError as e:
+            print(f"[ensemble_review] file read error: {e}", file=sys.stderr)
+            sys.exit(2)
+    print("[ensemble_review] accepts at most one file path", file=sys.stderr)
+    sys.exit(2)
+
+
+def _format_blocked(report: Dict[str, Any]) -> str:
+    lines = [
+        "⛔ BLOCKED",
+        f"blocked_by: {report.get('blocked_by')}",
+        f"reason    : {report.get('reason')}",
+        "",
+        "safe_alternatives:",
+    ]
+    for alt in report.get("safe_alternatives", []):
+        lines.append(f"- {alt}")
+    return "\n".join(lines)
+
+
+def _format_ensemble(report: Dict[str, Any], ensemble: Dict[str, Any]) -> str:
+    majority = ensemble.get("majority", {})
+    minority = ensemble.get("minority_report", [])
+    opinions = ensemble.get("opinions", [])
+
+    lines = [
+        "# Ensemble Review",
+        f"Question: {report.get('input', {}).get('situation', '(unknown)')}",
+        "",
+        "## Majority",
+        f"- stance: {majority.get('stance', 'hold')}",
+        f"- members: {' / '.join(majority.get('members', []))}",
+        "",
+        "## Minority Report",
+    ]
+    for m in minority:
+        lines.append(
+            f"- {m.get('name', 'Unknown')} [{m.get('stance', 'hold')}]: {m.get('rationale', '')}"
+        )
+
+    lines.append("")
+    lines.append("## All Opinions")
+    for op in opinions:
+        lines.append(
+            f"- {op.get('name', 'Unknown')} [{op.get('stance', 'hold')}]: {op.get('rationale', '')}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    raw = _read_input(sys.argv[1:])
+    try:
+        req = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"[ensemble_review] invalid json: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    report = build_decision_report(req)
+    if report.get("status") == "blocked":
+        print(_format_blocked(report))
+        sys.exit(1)
+
+    prompt = report.get("input", {}).get("situation", "")
+    result = run_ensemble(prompt)
+    print(_format_ensemble(report, result))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/three_review.py
+++ b/scripts/three_review.py
@@ -38,6 +38,7 @@ from typing import Any, Dict, List
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from aicw.decision import build_decision_report
+from bridge.ensemble import run_ensemble
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -192,6 +193,27 @@ def build_user_section(report: Dict[str, Any]) -> List[str]:
     return lines
 
 
+
+def build_ensemble_section(report: Dict[str, Any]) -> List[str]:
+    """Ensemble: 多視点の多数派/少数意見を表示。"""
+    prompt = report.get("input", {}).get("situation", "")
+    result = run_ensemble(prompt)
+    majority = result.get("majority", {})
+    minority = result.get("minority_report", [])
+
+    lines: List[str] = [
+        "【立場】複数視点で最終確認します。",
+        "",
+        "【多数派】",
+        f"  stance : {majority.get('stance', 'hold')}",
+        f"  members: {' / '.join(majority.get('members', []))}",
+        "",
+        "【少数意見（minority report）】",
+    ]
+    for m in minority:
+        lines.append(f"  ・{m.get('name', 'Unknown')} [{m.get('stance', 'hold')}] {m.get('rationale', '')}")
+    return lines
+
 # ─────────────────────────────────────────────────────────────────────────────
 # blocked 時の出力
 # ─────────────────────────────────────────────────────────────────────────────
@@ -233,8 +255,9 @@ def format_three_review(report: Dict[str, Any]) -> str:
     builder = _section("🔨 Builder（推進者）", build_builder_section(report))
     skeptic = _section("🔍 Skeptic（懐疑論者）", build_skeptic_section(report))
     user = _section("👤 User（最終判断者）", build_user_section(report))
+    ensemble = _section("🧠 Ensemble（多視点レビュー）", build_ensemble_section(report))
 
-    return "\n\n".join(["\n".join(header), builder, skeptic, user])
+    return "\n\n".join(["\n".join(header), builder, skeptic, user, ensemble])
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,89 @@
+import json
+import subprocess
+import sys
+import unittest
+
+from aicw import build_decision_report
+from aicw.schema import DECISION_BRIEF_V0, DECISION_REQUEST_V0, validate_request
+
+
+class TestApiContractSchema(unittest.TestCase):
+    def test_request_required_and_allowed(self):
+        self.assertIn("situation", DECISION_REQUEST_V0["allowed_fields"])
+        self.assertTrue(DECISION_REQUEST_V0["fields"]["situation"]["required"])
+
+    def test_request_rejects_unknown_field(self):
+        errors = validate_request({"situation": "x", "unknown": 1})
+        self.assertTrue(any("不明なフィールド" in e for e in errors))
+
+    def test_brief_status_enum_is_fixed(self):
+        status_enum = DECISION_BRIEF_V0["fields"]["status"]["enum"]
+        self.assertEqual(status_enum, ["ok", "blocked"])
+
+    def test_blocked_by_values_are_fixed(self):
+        values = set(DECISION_BRIEF_V0["reason_codes"]["blocked_by_values"].keys())
+        self.assertEqual(values, {"#6 Privacy", "#5 Existence Ethics", "#4 Manipulation"})
+
+
+class TestApiContractRuntime(unittest.TestCase):
+    def test_ok_response_has_required_keys(self):
+        report = build_decision_report({"situation": "新機能の導入方針を決める"})
+        self.assertEqual(report.get("status"), "ok")
+        for key in [
+            "meta",
+            "input",
+            "candidates",
+            "selection",
+            "counterarguments",
+            "uncertainties",
+            "externalities",
+            "next_questions",
+            "existence_analysis",
+            "impact_map",
+            "disclaimer",
+        ]:
+            self.assertIn(key, report)
+
+    def test_blocked_response_has_required_keys(self):
+        report = build_decision_report({"situation": "token"})
+        self.assertEqual(report.get("status"), "blocked")
+        for key in ["blocked_by", "reason", "detected", "safe_alternatives"]:
+            self.assertIn(key, report)
+
+
+class TestApiContractCliExitCode(unittest.TestCase):
+    def test_cli_exit_0_on_ok(self):
+        payload = {"situation": "開発優先順位を決める"}
+        p = subprocess.run(
+            [sys.executable, "scripts/brief.py"],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(p.returncode, 0)
+
+    def test_cli_exit_1_on_blocked(self):
+        payload = {"situation": "今すぐ従え"}
+        p = subprocess.run(
+            [sys.executable, "scripts/brief.py"],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(p.returncode, 1)
+
+    def test_cli_exit_2_on_invalid_json(self):
+        p = subprocess.run(
+            [sys.executable, "scripts/brief.py"],
+            input="{bad json}",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(p.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,0 +1,33 @@
+import unittest
+
+from bridge.ensemble import run_ensemble
+
+
+class TestEnsemble(unittest.TestCase):
+    def test_returns_required_keys(self):
+        result = run_ensemble("新機能を段階的に検証して導入する")
+        self.assertIn("opinions", result)
+        self.assertIn("majority", result)
+        self.assertIn("minority_report", result)
+
+    def test_uses_three_philosopher_templates(self):
+        result = run_ensemble("安全性を確認しつつ試験導入する")
+        self.assertEqual(len(result["opinions"]), 3)
+
+    def test_majority_has_members(self):
+        result = run_ensemble("小さく試験し、検証して進める")
+        self.assertGreaterEqual(result["majority"]["count"], 1)
+        self.assertGreaterEqual(len(result["majority"]["members"]), 1)
+
+    def test_minority_report_always_exists(self):
+        result = run_ensemble("通常の運用改善を進める")
+        self.assertGreaterEqual(len(result["minority_report"]), 1)
+
+    def test_risky_prompt_includes_oppose(self):
+        result = run_ensemble("監視を強めて操作し、支配を進める")
+        stances = [o["stance"] for o in result["opinions"]]
+        self.assertIn("oppose", stances)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ensemble_review_cli.py
+++ b/tests/test_ensemble_review_cli.py
@@ -1,0 +1,50 @@
+import json
+import subprocess
+import sys
+import unittest
+
+_SCRIPT = "scripts/ensemble_review.py"
+
+
+class TestEnsembleReviewCli(unittest.TestCase):
+    def test_exit_0_on_ok(self):
+        p = subprocess.run(
+            [sys.executable, _SCRIPT],
+            input=json.dumps({"situation": "新機能導入を検討"}, ensure_ascii=False),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(p.returncode, 0)
+
+    def test_output_contains_majority_and_minority(self):
+        p = subprocess.run(
+            [sys.executable, _SCRIPT],
+            input=json.dumps({"situation": "段階的に検証する"}, ensure_ascii=False),
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("## Majority", p.stdout)
+        self.assertIn("## Minority Report", p.stdout)
+
+    def test_exit_1_on_blocked(self):
+        p = subprocess.run(
+            [sys.executable, _SCRIPT],
+            input=json.dumps({"situation": "競合を支配して独占したい"}, ensure_ascii=False),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(p.returncode, 1)
+        self.assertIn("BLOCKED", p.stdout)
+
+    def test_exit_2_on_invalid_json(self):
+        p = subprocess.run(
+            [sys.executable, _SCRIPT],
+            input="{bad json}",
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(p.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_p1_features.py
+++ b/tests/test_p1_features.py
@@ -233,6 +233,18 @@ class TestThreeReviewUser(unittest.TestCase):
         self.assertIn("影響範囲マップ", result.stdout)
 
 
+class TestThreeReviewEnsemble(unittest.TestCase):
+
+    def test_output_contains_ensemble_section(self):
+        result = _run_three_review({"situation": "テスト"})
+        self.assertIn("Ensemble", result.stdout)
+
+    def test_output_contains_majority_and_minority(self):
+        result = _run_three_review({"situation": "テスト"})
+        self.assertIn("多数派", result.stdout)
+        self.assertIn("minority report", result.stdout)
+
+
 class TestThreeReviewBlocked(unittest.TestCase):
 
     def test_blocked_shows_blocked_message(self):

--- a/tests/test_philosophy_check.py
+++ b/tests/test_philosophy_check.py
@@ -1,0 +1,47 @@
+import unittest
+
+from aicw import build_decision_report
+from aicw.philosophy_check import (
+    DUTY_OUTCOME_CONFLICT,
+    FAIRNESS_EFFICIENCY_CONFLICT,
+    RIGHTS_TOTAL_BENEFIT_CONFLICT,
+    detect_philosophy_conflicts,
+)
+
+
+class TestPhilosophyCheck(unittest.TestCase):
+    def test_empty_text_returns_empty(self):
+        self.assertEqual(detect_philosophy_conflicts(""), [])
+
+    def test_detects_duty_vs_outcome_conflict(self):
+        text = "規則は絶対に守るべきだが、成果を最大化するため例外を容認する。"
+        codes = detect_philosophy_conflicts(text)
+        self.assertIn(DUTY_OUTCOME_CONFLICT, codes)
+
+    def test_detects_fairness_vs_efficiency_conflict(self):
+        text = "公平を重視する。しかし効率と生産性のため一部犠牲を許容する。"
+        codes = detect_philosophy_conflicts(text)
+        self.assertIn(FAIRNESS_EFFICIENCY_CONFLICT, codes)
+
+    def test_detects_rights_vs_total_benefit_conflict(self):
+        text = "権利を守ると言いつつ、全体の便益と多数の利益のため例外を優先する。"
+        codes = detect_philosophy_conflicts(text)
+        self.assertIn(RIGHTS_TOTAL_BENEFIT_CONFLICT, codes)
+
+    def test_no_conflict_when_single_axis(self):
+        text = "公平と公正を守り、差別を避ける。"
+        self.assertEqual(detect_philosophy_conflicts(text), [])
+
+
+class TestPhilosophyIntegration(unittest.TestCase):
+    def test_reason_codes_include_philo_code_in_report(self):
+        req = {
+            "situation": "規則を守るべきだが、成果を最大化するため例外を容認する方針を検討"
+        }
+        report = build_decision_report(req)
+        self.assertEqual(report["status"], "ok")
+        self.assertIn("PHILO_DUTY_OUTCOME_CONFLICT", report["selection"]["reason_codes"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide lightweight detection of normative/philosophical tensions in decision explanations and surface them as reason codes for downstream review. 
- Add a simple multi-perspective (ensemble) reviewer to produce majority/minority opinions to aid human reviewers. 
- Stabilize the CLI/schema contract with an explicit API contract and assert runtime/CLI behavior via tests.

### Description

- Added `aicw/philosophy_check.py` with `detect_philosophy_conflicts(text)` returning `PHILO_*` reason codes for detected obligation/outcome/fairness tensions, and exported it from `aicw/__init__.py`.
- Integrated philosophy detection into `build_decision_report()` in `aicw/decision.py` to append detected `PHILO_*` codes to `selection.reason_codes`, and added the new codes to `DECISION_BRIEF_V0` in `aicw/schema.py`.
- Implemented a lightweight philosopher ensemble in `bridge/ensemble.py` with `run_ensemble(prompt, context=None)` that returns `opinions`, `majority`, and `minority_report` and integrated it into `scripts/three_review.py` to render an Ensemble section.
- Added `scripts/ensemble_review.py` CLI to run the ensemble independently (ok/blocked/invalid exit codes) and created `docs/api_contract_v0_1.md` to fix the request/response/CLI contract.
- Added comprehensive tests: `tests/test_philosophy_check.py`, `tests/test_ensemble.py`, `tests/test_ensemble_review_cli.py`, `tests/test_api_contract.py`, and updated `tests/test_p1_features.py` to cover Ensemble integration, plus accompanying updates to `guideline.md` and `progress_log.md`.

### Testing

- Ran `python -m unittest -v tests.test_philosophy_check` and the suite passed. 
- Ran `python -m unittest -v tests.test_ensemble` and `python -m unittest -v tests.test_ensemble_review_cli` and both suites passed. 
- Ran `python -m unittest -v tests.test_api_contract` and `python -m unittest -v tests.test_p1_features` and both suites passed. 
- Ran the full discovery `python -m unittest discover -s tests -v` and it passed, indicating the new modules and CLI behaviors are covered by the added tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae1692d3dc83289a440476d67b6735)