### PR TITLE
Add meta_suggest CLI to recommend next actionable tasks

### DIFF
--- a/guideline.md
+++ b/guideline.md
@@ -186,3 +186,4 @@ python run_demo.py
 - [x] Task8 接続: 哲学的矛盾検知（PHILO_*）を decision.selection.reason_codes に統合
 - [x] three_review に Ensemble（多数派/少数意見）セクションを統合
 - [x] scripts/ensemble_review.py を追加（Ensemble 単体CLI + blocked分岐）
+- [x] scripts/meta_suggest.py を追加（未完了タスクから次アクション3案を提案するメタモジュール）

--- a/idea_note.md
+++ b/idea_note.md
@@ -88,17 +88,17 @@
 
 ### カテゴリ2: 哲学的・説明性向上
 
-- [ ] (2026-02-28) Idea: 軽量「哲学者アンサンブル」シミュレーター（Po_core プレビュー版）
+- [x] (2026-02-28) Idea: 軽量「哲学者アンサンブル」シミュレーター（Po_core プレビュー版）
   - Source: Grok
   - Why: 本格 Po_core 連携前に、このリポジトリだけで「哲学的議論」を体現し、説得力を高める
-  - Notes: Kant / Nietzsche / Rawls など 5〜7人の簡易テンプレートを bridge/ に定義し、多数決＋反対意見リストを自動生成。HiroshiTanaka と同じ Philosopher 継承で実装できる。外部依存なし
-  - Status: backlog
+  - Notes: 3哲学者テンプレート（HiroshiTanaka / Pragmatist / RightsGuardian）を `bridge/ensemble.py` に実装し、多数派意見 + 少数意見（全会一致時は SystemMinority 補完）を返す設計で完了（2026-03-09 session 11）。
+  - Status: done
 
-- [ ] (2026-02-28) Idea: 「哲学的矛盾検知」モジュール
+- [x] (2026-02-28) Idea: 「哲学的矛盾検知」モジュール
   - Source: Grok
   - Why: 決定理由の中に「義務論と功利主義が矛盾してる」みたいな哲学的齟齬を指摘するため
-  - Notes: 簡易論理矛盾チェック＋哲学キーワードマッチ。Po_core の Skeptic 役として組み込める
-  - Status: backlog
+  - Notes: `aicw/philosophy_check.py` で 3系統（義務論/功利、公正/効率、権利/総便益）の矛盾 reason code 検知を実装し、`aicw/decision.py` 側の `reason_codes` にも接続済み（2026-03-09 session 11）。
+  - Status: done
 
 - [x] (2026-02-28) Idea: 「不確実性マップ」自動生成機能
   - Source: Grok
@@ -148,11 +148,11 @@
 
 ### カテゴリ5: メタ・自己改善
 
-- [ ] (2026-02-28) Idea: 「このリポジトリ自身を改善する提案」を AI が出すメタモジュール
+- [x] (2026-02-28) Idea: 「このリポジトリ自身を改善する提案」を AI が出すメタモジュール
   - Source: Grok
   - Why: タイトル通りの「AIがAIを作る」循環を安全に体験するため（人間レビュー必須）
-  - Notes: 毎回 progress_log.md / guideline.md を読んで「次にやるべきこと」を3案出す。scripts/meta_suggest.py として実装。外部 API 不使用
-  - Status: backlog
+  - Notes: `scripts/meta_suggest.py` と `tests/test_meta_suggest.py` を追加し、未完了チェックボックスを収集して上位3提案をJSONで返すCLIとして実装（2026-03-09 session 16）。外部 API 不使用
+  - Status: done
 
 ---
 

--- a/progress_log.md
+++ b/progress_log.md
@@ -692,3 +692,25 @@ impact_score = min(構造層数 + risk_bonus, 8) ／ threshold=6 で A にオー
 ### Test Results
 - `PYTHONPATH=. pytest -q tests/test_uncertainty_map.py` → 7 passed
 - `PYTHONPATH=. pytest -q` → 412 passed, 20 subtests passed
+
+## 2026-03-09 (session 16 — Backlog: メタ改善提案モジュール)
+
+### Goal
+- Backlog「このリポジトリ自身を改善する提案」を出すメタモジュールを実装する
+
+### Done
+- `scripts/meta_suggest.py`（新規）:
+  - `guideline.md` / `progress_log.md` / `idea_note.md` を走査し、`- [ ]` の未完了項目を抽出
+  - 優先順位（guideline > idea_note > progress_log）で上位 `top_k` 件（既定3件）を提案JSONとして出力
+  - 未完了項目がない場合のフォールバック提案を実装
+  - CLI引数: `python scripts/meta_suggest.py [top_k]`（不正引数は exit code 2）
+- `tests/test_meta_suggest.py`（新規）:
+  - 未完了項目抽出と優先順位、フォールバック、`top_k` バリデーション、CLI正常系/異常系を検証（5件）
+- `idea_note.md`:
+  - Backlog の「哲学者アンサンブル」「哲学的矛盾検知」「メタモジュール」を done に同期
+- `guideline.md`:
+  - Current Next Actions に `scripts/meta_suggest.py` 完了を追記
+
+### Test Results
+- `python -m unittest -v tests.test_meta_suggest` PASS
+- `python -m unittest discover -s tests -v` PASS

--- a/scripts/meta_suggest.py
+++ b/scripts/meta_suggest.py
@@ -1,0 +1,108 @@
+"""Repository self-improvement suggester.
+
+Reads project docs and prints top 3 actionable suggestions.
+Standard library only.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+DEFAULT_FILES = [
+    "guideline.md",
+    "progress_log.md",
+    "idea_note.md",
+]
+
+
+def _extract_unchecked_tasks(text: str) -> List[str]:
+    tasks: List[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- [ ] "):
+            tasks.append(stripped[6:].strip())
+    return tasks
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def build_suggestions(base_dir: Path, top_k: int = 3) -> Dict[str, object]:
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+
+    all_tasks: List[Dict[str, str]] = []
+    for rel in DEFAULT_FILES:
+        p = base_dir / rel
+        content = _read_text(p)
+        for task in _extract_unchecked_tasks(content):
+            all_tasks.append({"source": rel, "task": task})
+
+    # prioritize core guidance first, then ideas/progress.
+    priority = {"guideline.md": 0, "idea_note.md": 1, "progress_log.md": 2}
+    all_tasks.sort(key=lambda x: priority.get(x["source"], 9))
+
+    picked = all_tasks[:top_k]
+    suggestions = []
+    for idx, item in enumerate(picked, start=1):
+        suggestions.append(
+            {
+                "rank": idx,
+                "proposal": item["task"],
+                "source": item["source"],
+                "rationale": "未完了タスクのため、次スプリント候補として優先。",
+            }
+        )
+
+    if not suggestions:
+        suggestions.append(
+            {
+                "rank": 1,
+                "proposal": "未完了タスクが見つからないため、既存テストの回帰実行と文書同期を行う",
+                "source": "system",
+                "rationale": "運用品質維持のための保守タスク。",
+            }
+        )
+
+    return {
+        "summary": {
+            "scanned_files": DEFAULT_FILES,
+            "total_candidates": len(all_tasks),
+            "returned": len(suggestions),
+        },
+        "suggestions": suggestions,
+    }
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) > 2:
+        print("Usage: python scripts/meta_suggest.py [top_k]", file=sys.stderr)
+        return 2
+
+    top_k = 3
+    if len(argv) == 2:
+        try:
+            top_k = int(argv[1])
+        except ValueError:
+            print("top_k must be an integer", file=sys.stderr)
+            return 2
+
+    try:
+        result = build_suggestions(Path.cwd(), top_k=top_k)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_meta_suggest.py
+++ b/tests/test_meta_suggest.py
@@ -1,0 +1,65 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.meta_suggest import build_suggestions
+
+
+class TestMetaSuggestCore(unittest.TestCase):
+    def test_build_suggestions_picks_unchecked(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text("- [ ] A task\n- [x] done\n", encoding="utf-8")
+            (root / "idea_note.md").write_text("- [ ] B task\n", encoding="utf-8")
+            (root / "progress_log.md").write_text("- [ ] C task\n", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=2)
+
+            self.assertEqual(result["summary"]["total_candidates"], 3)
+            self.assertEqual(result["summary"]["returned"], 2)
+            self.assertEqual(result["suggestions"][0]["proposal"], "A task")
+            self.assertEqual(result["suggestions"][1]["proposal"], "B task")
+
+    def test_build_suggestions_fallback_when_no_unchecked(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for name in ("guideline.md", "idea_note.md", "progress_log.md"):
+                (root / name).write_text("- [x] done\n", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=3)
+            self.assertEqual(result["summary"]["total_candidates"], 0)
+            self.assertEqual(result["suggestions"][0]["source"], "system")
+
+    def test_invalid_top_k(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(ValueError):
+                build_suggestions(Path(td), top_k=0)
+
+
+class TestMetaSuggestCLI(unittest.TestCase):
+    def test_cli_runs(self):
+        proc = subprocess.run(
+            ["python", "scripts/meta_suggest.py", "2"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0)
+        data = json.loads(proc.stdout)
+        self.assertIn("suggestions", data)
+
+    def test_cli_invalid_args(self):
+        proc = subprocess.run(
+            ["python", "scripts/meta_suggest.py", "abc"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("top_k must be an integer", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small meta-module that scans project docs for unfinished work and suggests the next actionable tasks to prioritize. 
- Make it easier to keep `guideline.md`/`idea_note.md`/`progress_log.md` synchronized and reduce manual triage when planning the next sprint.

### Description
- Added `scripts/meta_suggest.py`, a standard-library CLI that scans `guideline.md`, `progress_log.md`, and `idea_note.md` for `- [ ]` items and returns the top-`k` suggestions as JSON. 
- Prioritization favors `guideline.md` over `idea_note.md` and `progress_log.md`, supports `python scripts/meta_suggest.py [top_k]`, validates `top_k` (invalid → exit code `2`), and provides a fallback suggestion when no unchecked tasks exist. 
- Added `tests/test_meta_suggest.py` which covers extraction, prioritization, fallback behavior, `top_k` validation, and CLI success/error cases. 
- Synchronized documentation by updating `idea_note.md` and `guideline.md` to mark completed items and appended a session entry in `progress_log.md` describing the change.

### Testing
- Ran `python -m unittest -v tests.test_meta_suggest` and the new test suite passed (`OK`).
- Ran the full project test discovery with `python -m unittest discover -s tests -v` and the entire test suite passed in this environment. 
- The CLI was exercised in tests to verify exit codes and JSON output (successful/invalid-arg cases covered by unit tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae36c094248328abfc8a8d16c509a4)