### PR TITLE
meta_suggest: detect action headings, prioritize action-scoped tasks, and include README.md

### DIFF
--- a/scripts/meta_suggest.py
+++ b/scripts/meta_suggest.py
@@ -7,24 +7,79 @@ Standard library only.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 DEFAULT_FILES = [
     "guideline.md",
+    "README.md",
     "progress_log.md",
     "idea_note.md",
 ]
 
 
-def _extract_unchecked_tasks(text: str) -> List[str]:
-    tasks: List[str] = []
+_ACTION_HEADING_HINTS = (
+    "current next actions",
+    "next actions",
+    "next steps",
+    "upcoming milestones",
+    "sprint plan",
+    "todo",
+)
+
+_BOLD_HEADING_WITH_SUFFIX_COLON_RE = re.compile(r"^\*\*(.+?)\*\*\s*:\s*$")
+_BOLD_HEADING_WITH_INNER_COLON_RE = re.compile(r"^\*\*(.+?:)\*\*\s*$")
+
+
+def _is_action_heading_text(heading: str) -> bool:
+    lowered = heading.lower().strip()
+    return any(hint in lowered for hint in _ACTION_HEADING_HINTS)
+
+
+def _classify_heading(line: str) -> Tuple[bool, bool]:
+    """Return (is_heading, is_action_heading)."""
+    stripped = line.strip()
+    lowered = stripped.lower()
+
+    if lowered.startswith("#"):
+        heading = lowered.lstrip("#").strip()
+        return True, _is_action_heading_text(heading)
+
+    # README の "**Upcoming Milestones (2026):**" / "**Todo**:" のような見出し記法に対応
+    # 太字行は「コロン付き」の場合のみ見出しとして扱い、通常の強調文を誤検知しない。
+    m = _BOLD_HEADING_WITH_SUFFIX_COLON_RE.match(stripped)
+    if not m:
+        m = _BOLD_HEADING_WITH_INNER_COLON_RE.match(stripped)
+    if m:
+        heading = m.group(1).strip().rstrip(":")
+        return True, _is_action_heading_text(heading)
+
+    return False, False
+
+
+def _extract_unchecked_tasks(text: str) -> List[Dict[str, object]]:
+    unchecked_anywhere: List[Dict[str, object]] = []
+    in_action_section = False
+
     for line in text.splitlines():
         stripped = line.strip()
+
+        is_heading, is_action_heading = _classify_heading(stripped)
+        if is_heading:
+            in_action_section = is_action_heading
+            continue
+
         if stripped.startswith("- [ ] "):
-            tasks.append(stripped[6:].strip())
-    return tasks
+            unchecked_anywhere.append(
+                {
+                    "task": stripped[6:].strip(),
+                    "is_action_scoped": in_action_section,
+                }
+            )
+
+    return unchecked_anywhere
 
 
 def _read_text(path: Path) -> str:
@@ -38,16 +93,33 @@ def build_suggestions(base_dir: Path, top_k: int = 3) -> Dict[str, object]:
     if top_k <= 0:
         raise ValueError("top_k must be positive")
 
-    all_tasks: List[Dict[str, str]] = []
+    all_tasks: List[Dict[str, object]] = []
     for rel in DEFAULT_FILES:
         p = base_dir / rel
         content = _read_text(p)
-        for task in _extract_unchecked_tasks(content):
-            all_tasks.append({"source": rel, "task": task})
+        for item in _extract_unchecked_tasks(content):
+            all_tasks.append(
+                {
+                    "source": rel,
+                    "task": item["task"],
+                    "is_action_scoped": bool(item["is_action_scoped"]),
+                }
+            )
 
-    # prioritize core guidance first, then ideas/progress.
-    priority = {"guideline.md": 0, "idea_note.md": 1, "progress_log.md": 2}
-    all_tasks.sort(key=lambda x: priority.get(x["source"], 9))
+    # 1) action-scoped を常に優先
+    # 2) その上で source 優先度を適用
+    priority = {
+        "guideline.md": 0,
+        "README.md": 1,
+        "idea_note.md": 2,
+        "progress_log.md": 3,
+    }
+    all_tasks.sort(
+        key=lambda x: (
+            0 if x["is_action_scoped"] else 1,
+            priority.get(str(x["source"]), 9),
+        )
+    )
 
     picked = all_tasks[:top_k]
     suggestions = []

--- a/tests/test_meta_suggest.py
+++ b/tests/test_meta_suggest.py
@@ -12,25 +12,156 @@ class TestMetaSuggestCore(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             (root / "guideline.md").write_text("- [ ] A task\n- [x] done\n", encoding="utf-8")
+            (root / "README.md").write_text("- [ ] R task\n", encoding="utf-8")
             (root / "idea_note.md").write_text("- [ ] B task\n", encoding="utf-8")
             (root / "progress_log.md").write_text("- [ ] C task\n", encoding="utf-8")
 
             result = build_suggestions(root, top_k=2)
 
-            self.assertEqual(result["summary"]["total_candidates"], 3)
+            self.assertEqual(result["summary"]["total_candidates"], 4)
             self.assertEqual(result["summary"]["returned"], 2)
             self.assertEqual(result["suggestions"][0]["proposal"], "A task")
-            self.assertEqual(result["suggestions"][1]["proposal"], "B task")
+            self.assertEqual(result["suggestions"][1]["proposal"], "R task")
 
     def test_build_suggestions_fallback_when_no_unchecked(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
-            for name in ("guideline.md", "idea_note.md", "progress_log.md"):
+            for name in ("guideline.md", "README.md", "idea_note.md", "progress_log.md"):
                 (root / name).write_text("- [x] done\n", encoding="utf-8")
 
             result = build_suggestions(root, top_k=3)
             self.assertEqual(result["summary"]["total_candidates"], 0)
             self.assertEqual(result["suggestions"][0]["source"], "system")
+
+
+    def test_fallback_to_any_unchecked_when_non_action_headings_exist(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text("# Notes\n- [ ] still capture me\n", encoding="utf-8")
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=1)
+            self.assertEqual(result["summary"]["total_candidates"], 1)
+            self.assertEqual(result["suggestions"][0]["proposal"], "still capture me")
+
+
+    def test_non_action_bold_heading_resets_action_scope(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "**Upcoming Milestones (2026):**\n"
+                "- [ ] action task\n"
+                "**Notes:**\n"
+                "- [ ] note task\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=3)
+            self.assertEqual(result["summary"]["total_candidates"], 2)
+            self.assertEqual(result["suggestions"][0]["proposal"], "action task")
+
+    def test_inline_bold_sentence_is_not_treated_as_heading(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "Please keep **next steps** clear.\n"
+                "- [ ] plain task\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=1)
+            self.assertEqual(result["summary"]["total_candidates"], 1)
+            self.assertEqual(result["suggestions"][0]["proposal"], "plain task")
+
+
+    def test_bold_without_colon_is_not_heading(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "## Current Next Actions\n"
+                "**Phase 1**\n"
+                "- [ ] keep action scope\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=1)
+            self.assertEqual(result["summary"]["total_candidates"], 1)
+            self.assertEqual(result["suggestions"][0]["proposal"], "keep action scope")
+
+
+
+    def test_non_action_items_are_kept_when_action_section_exists(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "## Current Next Actions\n"
+                "- [ ] action item\n"
+                "## Notes\n"
+                "- [ ] non action item\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=5)
+            proposals = [s["proposal"] for s in result["suggestions"]]
+            self.assertEqual(result["summary"]["total_candidates"], 2)
+            self.assertEqual(proposals[0], "action item")
+            self.assertIn("non action item", proposals)
+
+    def test_action_scoped_tasks_are_prioritized_globally(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "## Safety Checklist\n"
+                "- [ ] generic checklist\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text(
+                "**Upcoming Milestones:**\n"
+                "- [ ] roadmap action\n",
+                encoding="utf-8",
+            )
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=1)
+            self.assertEqual(result["summary"]["total_candidates"], 2)
+            self.assertEqual(result["suggestions"][0]["proposal"], "roadmap action")
+            self.assertEqual(result["suggestions"][0]["source"], "README.md")
+
+
+    def test_generic_next_heading_is_not_treated_as_action(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "## Next\n"
+                "- [ ] generic next note\n"
+                "## Current Next Actions\n"
+                "- [ ] concrete action\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=2)
+            proposals = [s["proposal"] for s in result["suggestions"]]
+            self.assertEqual(result["summary"]["total_candidates"], 2)
+            self.assertEqual(proposals[0], "concrete action")
+            self.assertIn("generic next note", proposals)
 
     def test_invalid_top_k(self):
         with tempfile.TemporaryDirectory() as td:
@@ -59,6 +190,18 @@ class TestMetaSuggestCLI(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 2)
         self.assertIn("top_k must be an integer", proc.stderr)
+
+    def test_readme_tasks_are_considered(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text("- [x] done\n", encoding="utf-8")
+            (root / "README.md").write_text("- [ ] public roadmap task\n", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=1)
+            self.assertEqual(result["suggestions"][0]["proposal"], "public roadmap task")
+            self.assertEqual(result["suggestions"][0]["source"], "README.md")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Improve task extraction accuracy by recognizing common action-oriented headings and README-stored tasks.
- Ensure high-signal "action" sections are prioritized when generating suggestions.
- Avoid misclassifying inline bold text as headings while supporting bold heading styles like `**Upcoming Milestones:**`.

### Description
- Added `README.md` to `DEFAULT_FILES` and updated the priority ordering to include it.
- Reworked `_extract_unchecked_tasks` to return task metadata including an `is_action_scoped` flag and to track whether the current section is an action heading. The function now uses `_classify_heading` and `_is_action_heading_text` helpers to detect headings.
- Introduced regex-based detection for bold-heading-with-colon patterns and robust handling for Markdown `#` headings to identify action sections using `_ACTION_HEADING_HINTS`.
- Updated sorting so that action-scoped tasks are always prioritized globally, then by source priority, before selecting top-k suggestions.
- Updated the output construction and fallback suggestion when no unchecked tasks are found.
- Extended and added multiple unit tests in `tests/test_meta_suggest.py` to cover README inclusion, heading classification edge cases, action scoping, prioritization, and CLI behavior.

### Testing
- Ran the unit test module `tests/test_meta_suggest.py` via `python -m unittest`, which exercises extraction, prioritization, heading classification, CLI invocation, and invalid-arg handling; all tests passed.
- Verified the CLI (`python scripts/meta_suggest.py`) returns JSON with a `suggestions` field as asserted by tests; the CLI-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae3e4fbd8083288de5e2d86802bf62)