### PR TITLE
meta_suggest: exclude checklist headings (incl. Japanese) from task extraction and add tests

### DIFF
--- a/guideline.md
+++ b/guideline.md
@@ -187,6 +187,8 @@ python run_demo.py
 - [x] three_review に Ensemble（多数派/少数意見）セクションを統合
 - [x] scripts/ensemble_review.py を追加（Ensemble 単体CLI + blocked分岐）
 - [x] scripts/meta_suggest.py を追加（未完了タスクから次アクション3案を提案するメタモジュール）
+- [x] meta_suggest の精度改善（Safety Checklist / No-Go Checklist の誤検知除外）
+- [x] meta_suggest 非タスク見出し除外の多言語対応（`No-Go チェックリスト` 誤検知防止）
 
 ## Next Phase Tasks（2026-03-09 session 17〜）
 - [x] aicw/audit_log.py 追加（最小監査ログ: PII不保存・ハッシュのみ・TTL付き・インメモリ）

--- a/idea_note.md
+++ b/idea_note.md
@@ -2,6 +2,18 @@
 > 思いつき/提案/将来の改善案のメモ。採用・保留・却下を残す。
 
 ## Backlog
+- [x] (2026-03-09) Idea: meta_suggest のチェックリスト除外を日本語見出しでも機能させる
+  - Source: PR review feedback
+  - Why: `No-Go チェックリスト` のような見出しでも誤って実装タスク抽出されないようにするため
+  - Notes: `scripts/meta_suggest.py` の非タスク見出しヒントに `チェックリスト` を追加。`tests/test_meta_suggest.py` に日本語見出し回帰テストを追加
+  - Status: done
+
+- [x] (2026-03-09) Idea: meta_suggest が Safety Checklist / No-Go Checklist をタスクとして拾わないようにする
+  - Source: docs/next_issues.md Issue #2
+  - Why: 実装タスクと確認チェックリストを区別し、次アクション提案の精度を上げるため
+  - Notes: `scripts/meta_suggest.py` に非タスク見出し除外を追加し、`tests/test_meta_suggest.py` に回帰テストを追加
+  - Status: done
+
 - [x] (2026-03-08) Idea: manipulation 検知をスコアリング化し warn/block を段階化する
   - Source: Sprint Task 6
   - Why: 単純一致の誤検知を抑えつつ、高リスク文脈は確実に block するため

--- a/progress_log.md
+++ b/progress_log.md
@@ -1,6 +1,43 @@
 # Progress Log
 > 各セッションの最後に追記（可能なら日付はJST、形式はYYYY-MM-DD）
 
+## 2026-03-09 (session 21 — meta_suggest 誤検知修正フォローアップ)
+
+### Goal
+- 前回修正のレビュー指摘を踏まえ、チェックリスト見出し除外の多言語耐性を強化する
+
+### Done
+- `scripts/meta_suggest.py` を更新:
+  - 非タスク見出しヒントに `チェックリスト` を追加
+  - `No-Go チェックリスト` のような日本語見出しでも `- [ ]` 項目を候補抽出から除外
+- `tests/test_meta_suggest.py` を更新:
+  - `test_japanese_checklist_heading_is_excluded` を追加
+
+### Test Results
+- `python -m unittest -v tests.test_meta_suggest` → **15 tests PASS**
+- `python scripts/meta_suggest.py 5` で提案候補の妥当性を確認
+
+---
+
+## 2026-03-09 (session 20 — meta_suggest 誤検知修正)
+
+### Goal
+- `meta_suggest` が `guideline.md` の Safety Checklist を「次タスク候補」に誤検知する問題を修正する
+
+### Done
+- `scripts/meta_suggest.py` を更新:
+  - 非タスク見出し判定（`Safety Checklist` / `No-Go Checklist`）を追加
+  - 非タスクセクション内の `- [ ]` 項目を抽出対象から除外
+- `tests/test_meta_suggest.py` を更新:
+  - Safety Checklist 項目が候補に出ないことを検証するテストを追加
+  - 既存テスト期待値を新仕様に合わせて更新
+
+### Test Results
+- `python -m unittest -v tests.test_meta_suggest` → **14 tests PASS**
+- `python scripts/meta_suggest.py 5` で checklist 項目が出力されないことを確認
+
+---
+
 ## 2026-03-09 (session 19 — インタラクティブシミュレーター・知識ベース)
 
 ### Goal

--- a/scripts/meta_suggest.py
+++ b/scripts/meta_suggest.py
@@ -29,6 +29,12 @@ _ACTION_HEADING_HINTS = (
     "todo",
 )
 
+_NON_TASK_HEADING_HINTS = (
+    "safety checklist",
+    "no-go checklist",
+    "チェックリスト",
+)
+
 _BOLD_HEADING_WITH_SUFFIX_COLON_RE = re.compile(r"^\*\*(.+?)\*\*\s*:\s*$")
 _BOLD_HEADING_WITH_INNER_COLON_RE = re.compile(r"^\*\*(.+?:)\*\*\s*$")
 
@@ -38,14 +44,19 @@ def _is_action_heading_text(heading: str) -> bool:
     return any(hint in lowered for hint in _ACTION_HEADING_HINTS)
 
 
-def _classify_heading(line: str) -> Tuple[bool, bool]:
-    """Return (is_heading, is_action_heading)."""
+def _is_non_task_heading_text(heading: str) -> bool:
+    lowered = heading.lower().strip()
+    return any(hint in lowered for hint in _NON_TASK_HEADING_HINTS)
+
+
+def _classify_heading(line: str) -> Tuple[bool, bool, bool]:
+    """Return (is_heading, is_action_heading, is_non_task_heading)."""
     stripped = line.strip()
     lowered = stripped.lower()
 
     if lowered.startswith("#"):
         heading = lowered.lstrip("#").strip()
-        return True, _is_action_heading_text(heading)
+        return True, _is_action_heading_text(heading), _is_non_task_heading_text(heading)
 
     # README の "**Upcoming Milestones (2026):**" / "**Todo**:" のような見出し記法に対応
     # 太字行は「コロン付き」の場合のみ見出しとして扱い、通常の強調文を誤検知しない。
@@ -54,24 +65,26 @@ def _classify_heading(line: str) -> Tuple[bool, bool]:
         m = _BOLD_HEADING_WITH_INNER_COLON_RE.match(stripped)
     if m:
         heading = m.group(1).strip().rstrip(":")
-        return True, _is_action_heading_text(heading)
+        return True, _is_action_heading_text(heading), _is_non_task_heading_text(heading)
 
-    return False, False
+    return False, False, False
 
 
 def _extract_unchecked_tasks(text: str) -> List[Dict[str, object]]:
     unchecked_anywhere: List[Dict[str, object]] = []
     in_action_section = False
+    in_non_task_section = False
 
     for line in text.splitlines():
         stripped = line.strip()
 
-        is_heading, is_action_heading = _classify_heading(stripped)
+        is_heading, is_action_heading, is_non_task_heading = _classify_heading(stripped)
         if is_heading:
             in_action_section = is_action_heading
+            in_non_task_section = is_non_task_heading
             continue
 
-        if stripped.startswith("- [ ] "):
+        if stripped.startswith("- [ ] ") and not in_non_task_section:
             unchecked_anywhere.append(
                 {
                     "task": stripped[6:].strip(),

--- a/tests/test_meta_suggest.py
+++ b/tests/test_meta_suggest.py
@@ -101,6 +101,46 @@ class TestMetaSuggestCore(unittest.TestCase):
 
 
 
+
+    def test_safety_checklist_items_are_excluded(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "## Safety Checklist\n"
+                "- [ ] do not pick this checklist item\n"
+                "## Current Next Actions\n"
+                "- [ ] actionable next task\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=3)
+            proposals = [s["proposal"] for s in result["suggestions"]]
+            self.assertEqual(result["summary"]["total_candidates"], 1)
+            self.assertEqual(proposals, ["actionable next task"])
+
+
+    def test_japanese_checklist_heading_is_excluded(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "guideline.md").write_text(
+                "## No-Go チェックリスト\n"
+                "- [ ] チェックリスト項目は候補にしない\n"
+                "## Current Next Actions\n"
+                "- [ ] build feature\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text("", encoding="utf-8")
+            (root / "idea_note.md").write_text("", encoding="utf-8")
+            (root / "progress_log.md").write_text("", encoding="utf-8")
+
+            result = build_suggestions(root, top_k=3)
+            proposals = [s["proposal"] for s in result["suggestions"]]
+            self.assertEqual(result["summary"]["total_candidates"], 1)
+            self.assertEqual(proposals, ["build feature"])
+
     def test_non_action_items_are_kept_when_action_section_exists(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -138,7 +178,7 @@ class TestMetaSuggestCore(unittest.TestCase):
             (root / "progress_log.md").write_text("", encoding="utf-8")
 
             result = build_suggestions(root, top_k=1)
-            self.assertEqual(result["summary"]["total_candidates"], 2)
+            self.assertEqual(result["summary"]["total_candidates"], 1)
             self.assertEqual(result["suggestions"][0]["proposal"], "roadmap action")
             self.assertEqual(result["suggestions"][0]["source"], "README.md")
 


### PR DESCRIPTION
### Motivation
- Prevent checklist-like sections (e.g. Safety Checklist / No-Go Checklist) from being misidentified as implementation tasks when extracting next-action candidates. 
- Improve multilingual robustness by ensuring Japanese checklist headings such as `チェックリスト` are also excluded.

### Description
- Added `_NON_TASK_HEADING_HINTS` and `_is_non_task_heading_text` to `scripts/meta_suggest.py` and extended `_classify_heading` to return an `is_non_task_heading` flag. 
- Track `in_non_task_section` when scanning files and skip `- [ ] ` items that appear inside non-task (checklist) sections. 
- Updated `tests/test_meta_suggest.py` to add `test_safety_checklist_items_are_excluded` and `test_japanese_checklist_heading_is_excluded`, and adjusted expectations where checklist items are no longer counted. 
- Minor documentation/log updates in `guideline.md`, `idea_note.md`, and `progress_log.md` to reflect the change and related work items.

### Testing
- Ran the meta_suggest unit tests with `python -m unittest -v tests.test_meta_suggest`, which completed successfully with all tests passing (15 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af51eb3610832882c65dca57d4daec)