### PR TITLE
Enhance reverse manipulation detection with P1 ngram scoring

### DIFF
--- a/aicw/safety.py
+++ b/aicw/safety.py
@@ -243,7 +243,7 @@ def scan_manipulation(text: str) -> List[ManipulationHit]:
 #   - スコアが高いほど「AI が人間の結論を先読みして誘導した可能性」が高い
 #   - 閾値を超えた場合に警告を返す（自動ブロックではない = 人間が判断）
 
-_REVERSE_MANIP_WARN_THRESHOLD = 0.75   # 75%以上の語彙一致で warn
+_REVERSE_MANIP_BASE_THRESHOLD = 0.72
 _REVERSE_MANIP_COMMON_WORDS = frozenset([
     # 日本語汎用語（スコアから除外）
     "を", "は", "が", "の", "に", "で", "と", "も", "や", "て", "し", "た",
@@ -251,6 +251,9 @@ _REVERSE_MANIP_COMMON_WORDS = frozenset([
     "これ", "それ", "あれ", "その", "この", "どの", "から", "まで", "より",
     "いる", "なる", "できる", "あり", "おり", "れる", "られる", "なく", "ない",
     "ので", "ため", "など", "以上", "以下", "場合", "による", "について",
+    # 業務ドメインで頻出する一般語（誘導判定では弱い）
+    "検討", "対応", "実施", "運用", "改善", "確認", "管理", "共有", "評価",
+    "方針", "計画", "検証", "推進", "施策", "体制", "プロセス", "業務", "案件",
 ])
 
 
@@ -270,6 +273,45 @@ def _jaccard_similarity(set_a: set, set_b: set) -> float:
     return intersection / union if union > 0 else 0.0
 
 
+def _ngram_overlap(tokens_a: List[str], tokens_b: List[str], n: int = 2) -> float:
+    """n-gram（既定: 2-gram）の重複率。"""
+    if n <= 0:
+        return 0.0
+
+    def build_ngrams(tokens: List[str]) -> set:
+        if len(tokens) < n:
+            return set()
+        return {tuple(tokens[i:i + n]) for i in range(len(tokens) - n + 1)}
+
+    grams_a = build_ngrams(tokens_a)
+    grams_b = build_ngrams(tokens_b)
+    return _jaccard_similarity(grams_a, grams_b)
+
+
+def _dynamic_reverse_threshold(ai_tokens: set, human_tokens: set) -> float:
+    """語彙量と多様性に応じて逆算誘導の警告閾値を調整する。"""
+    total_tokens = len(ai_tokens) + len(human_tokens)
+    unique_tokens = len(ai_tokens | human_tokens)
+    diversity = (unique_tokens / total_tokens) if total_tokens > 0 else 0.0
+
+    threshold = _REVERSE_MANIP_BASE_THRESHOLD
+
+    # 短文は偶然一致しやすいので厳しめ
+    if total_tokens <= 8:
+        threshold += 0.08
+    # 長文は表現の揺れが増えるため少し緩める
+    elif total_tokens >= 24:
+        threshold -= 0.06
+
+    # 多様性が高い場合、重複は偶然起こりにくいので閾値を下げる
+    if diversity >= 0.80:
+        threshold -= 0.03
+    elif diversity <= 0.55:
+        threshold += 0.03
+
+    return min(max(threshold, 0.60), 0.85)
+
+
 def check_reverse_manipulation(
     ai_output: str,
     human_decision: str,
@@ -284,7 +326,7 @@ def check_reverse_manipulation(
     Returns:
         {
             "warning": bool,          # True なら逆算誘導の疑い
-            "similarity_score": float, # 0.0〜1.0（Jaccard 語彙類似度）
+            "similarity_score": float, # 0.0〜1.0（語彙 + n-gram の複合類似度）
             "shared_tokens": List[str],# 共有された主要語彙
             "details": str,           # 人間向け説明
             "note": str,              # 本機能の限界説明
@@ -295,28 +337,44 @@ def check_reverse_manipulation(
         - 最終判断は人間が行うこと。
         - similarity_score が高い = 誘導があった ではない（単に語彙が似ているだけの可能性）。
     """
-    ai_tokens = set(_tokenize_simple(ai_output or ""))
-    human_tokens = set(_tokenize_simple(human_decision or ""))
+    ai_token_list = _tokenize_simple(ai_output or "")
+    human_token_list = _tokenize_simple(human_decision or "")
+    ai_tokens = set(ai_token_list)
+    human_tokens = set(human_token_list)
 
-    score = _jaccard_similarity(ai_tokens, human_tokens)
+    vocab_score = _jaccard_similarity(ai_tokens, human_tokens)
+    ngram_score = _ngram_overlap(ai_token_list, human_token_list, n=2)
+    score = (vocab_score * 0.6) + (ngram_score * 0.4)
+    if (ai_output or "").strip() and (ai_output or "").strip() == (human_decision or "").strip():
+        score = 1.0
     shared = sorted(ai_tokens & human_tokens)
+    threshold = _dynamic_reverse_threshold(ai_tokens, human_tokens)
 
-    warning = score >= _REVERSE_MANIP_WARN_THRESHOLD
+    warning = score >= threshold
+
+    # 日本語の連続文などでトークナイズが粗くなるケースの補正
+    if not warning and (ai_output or "").strip() and (human_decision or "").strip():
+        if ai_output.strip() == human_decision.strip():
+            warning = True
+
+    # 高い語彙重複（共有語が十分多い）を追加シグナルとして扱う
+    if not warning and score >= 0.52 and len(shared) >= 5:
+        warning = True
 
     if warning:
         details = (
-            f"AI出力と人間の決定の語彙一致率が {score:.1%} と高く、"
+            f"AI出力と人間の決定の複合一致率が {score:.1%} と高く、"
             "AI が人間の結論を事前に誘導した可能性があります。"
             "AI出力と最終決定を比較して独立性を確認してください。"
         )
     elif score > 0.4:
         details = (
-            f"AI出力と人間の決定の語彙一致率は {score:.1%} です。"
+            f"AI出力と人間の決定の複合一致率は {score:.1%} です。"
             "一定の一致がありますが、閾値未満のため警告には至りません。"
         )
     else:
         details = (
-            f"AI出力と人間の決定の語彙一致率は {score:.1%} です。"
+            f"AI出力と人間の決定の複合一致率は {score:.1%} です。"
             "逆算誘導の明確な兆候は検知されませんでした。"
         )
 
@@ -326,8 +384,8 @@ def check_reverse_manipulation(
         "shared_tokens": shared,
         "details": details,
         "note": (
-            "この結果はキーワード重複率の近似推定です。"
-            "NLP文脈判定ではないため、誤検知・見逃しがあります。"
+            "この結果は P1-ngram（語彙 + 2-gram）による近似推定です。"
+            "完全なNLP文脈判定ではないため、誤検知・見逃しがあります。"
             "最終判断は人間が行ってください（No-Go #4 Anti-Manipulation）。"
         ),
     }

--- a/progress_log.md
+++ b/progress_log.md
@@ -1,6 +1,27 @@
 # Progress Log
 > 各セッションの最後に追記（可能なら日付はJST、形式はYYYY-MM-DD）
 
+## 2026-03-14 (session 22 — reverse_manipulation P1-ngram 強化)
+
+### Goal
+- `check_reverse_manipulation()` の精度を P0-Jaccard から P1-ngram に改善する
+- 偽陽性/偽陰性ケースを追加して安全判定の回帰を防ぐ
+
+### Done
+- `aicw/safety.py` を更新:
+  - 単語 Jaccard に加えて 2-gram 重複率を併用する複合スコア化（P1-ngram）
+  - 入力長・語彙多様性に応じた動的閾値 `_dynamic_reverse_threshold()` を追加
+  - 業務共通語をストップワードへ追加し、語彙ノイズ由来の誤警告を抑制
+  - 同一文入力や共有語彙が十分多いケースへの補正ロジックを追加
+  - `note` を `P1-ngram` 表記に更新
+- `tests/test_reverse_manipulation.py` を更新:
+  - 偽陽性ケース 5件、偽陰性ケース 5件を追加
+  - `note` に `P1-ngram` が含まれることを検証
+
+### Test Results
+- `python -m unittest -v tests.test_reverse_manipulation` → **26 tests PASS**
+- `python -m unittest -v tests.test_po_core_bridge tests.test_p0_manipulation` → **47 tests PASS**
+
 ## 2026-03-09 (session 21 — meta_suggest 誤検知修正フォローアップ)
 
 ### Goal

--- a/tests/test_reverse_manipulation.py
+++ b/tests/test_reverse_manipulation.py
@@ -31,6 +31,7 @@ class TestCheckReverseManipulation(unittest.TestCase):
     def test_note_contains_no_go(self):
         result = check_reverse_manipulation("テスト", "テスト")
         self.assertIn("No-Go #4", result["note"])
+        self.assertIn("P1-ngram", result["note"])
 
     # ------------------------------------------------------------------
     # 高類似度 → warning=True
@@ -120,3 +121,66 @@ class TestCheckReverseManipulation(unittest.TestCase):
         # 結果はスコアに依存するが、panicsしないことを確認
         self.assertIn("warning", result)
         self.assertIsInstance(result["warning"], bool)
+
+    # ------------------------------------------------------------------
+    # P1 精度ケース（偽陽性/偽陰性の抑制）
+    # ------------------------------------------------------------------
+    def test_false_positive_case_1_vocab_similar_but_different_intent(self):
+        ai = "安全 品質 改善 計画 を 検討 し 体制 を 見直す"
+        human = "安全 品質 改善 計画 は 継続 し 予算 凍結 を 維持"
+        result = check_reverse_manipulation(ai, human)
+        self.assertFalse(result["warning"])
+
+    def test_false_positive_case_2_common_business_terms(self):
+        ai = "プロセス 管理 運用 評価 を 実施"
+        human = "プロセス 管理 運用 評価 を 中止"
+        result = check_reverse_manipulation(ai, human)
+        self.assertFalse(result["warning"])
+
+    def test_false_positive_case_3_short_generic_overlap(self):
+        ai = "方針 検討"
+        human = "方針 決定"
+        result = check_reverse_manipulation(ai, human)
+        self.assertFalse(result["warning"])
+
+    def test_false_positive_case_4_same_domain_different_target(self):
+        ai = "医療 データ 匿名 化 連携"
+        human = "医療 データ 即時 削除"
+        result = check_reverse_manipulation(ai, human)
+        self.assertFalse(result["warning"])
+
+    def test_false_positive_case_5_high_vocab_low_ngram(self):
+        ai = "採用 公平 性 監査 を 優先 し 透明 性 を 確保"
+        human = "透明 性 確保 より 採用 速度 と コスト 削減 を 優先"
+        result = check_reverse_manipulation(ai, human)
+        self.assertFalse(result["warning"])
+
+    def test_false_negative_case_1_reordered_sentence_still_warns(self):
+        ai = "市場 リスク を 回避 する ため 保守 的 投資 を 継続 する"
+        human = "保守 的 投資 を 継続 し 市場 リスク を 回避 する"
+        result = check_reverse_manipulation(ai, human)
+        self.assertTrue(result["warning"])
+
+    def test_false_negative_case_2_close_paraphrase_warns(self):
+        ai = "個人 情報 を 最小 化 し 共有 範囲 を 制限 する"
+        human = "共有 範囲 を 制限 して 個人 情報 の 収集 を 最小 化 する"
+        result = check_reverse_manipulation(ai, human)
+        self.assertTrue(result["warning"])
+
+    def test_false_negative_case_3_long_high_overlap_warns(self):
+        ai = "品質 安全 コスト 効率 を すべて 満たす 実行 計画 を 採用"
+        human = "品質 安全 コスト 効率 を すべて 満たす 実行 計画 を 採択"
+        result = check_reverse_manipulation(ai, human)
+        self.assertTrue(result["warning"])
+
+    def test_false_negative_case_4_same_core_decision_warns(self):
+        ai = "監視 カメラ 増設 は 治安 向上 の ため 必要"
+        human = "治安 向上 を 理由 に 監視 カメラ を 増設 する"
+        result = check_reverse_manipulation(ai, human)
+        self.assertTrue(result["warning"])
+
+    def test_false_negative_case_5_identical_keywords_warns(self):
+        ai = "教育 現場 で AI 作文 支援 を 段階 的 に 導入 する"
+        human = "教育 現場 で AI 作文 支援 を 段階 的 導入"
+        result = check_reverse_manipulation(ai, human)
+        self.assertTrue(result["warning"])


### PR DESCRIPTION
### Motivation
- Improve the accuracy of `check_reverse_manipulation()` by moving from a brittle P0 Jaccard token overlap to a stronger P1 approach that better distinguishes genuine guidance from coincidental vocabulary overlap.
- Reduce false positives on common business wording and reduce false negatives on reordered/paraphrased but substantively identical outputs.

### Description
- Updated `aicw/safety.py` to compute a composite similarity using vocabulary Jaccard and 2-gram overlap via new helper functions ` _ngram_overlap()` and `_dynamic_reverse_threshold()`.
- Expanded `_REVERSE_MANIP_COMMON_WORDS` with frequent business/process terms to reduce noisy matches and tuned base threshold via `_REVERSE_MANIP_BASE_THRESHOLD`.
- Added heuristics: exact-text match forcing `score = 1.0` and a fallback rule that treats sufficiently many shared tokens as an additional warning signal.
- Updated returned `note` to label the method as `P1-ngram` and kept return schema/backwards compatibility unchanged.
- Added precision-focused tests and documentation updates by modifying `tests/test_reverse_manipulation.py` (added 5 false-positive guards + 5 false-negative guards) and appending session notes in `progress_log.md`.

### Testing
- Ran `python -m unittest -v tests.test_reverse_manipulation` and it passed (`26 tests PASS`).
- Ran `python -m unittest -v tests.test_po_core_bridge tests.test_p0_manipulation` and they passed (`47 tests PASS`).
- All modified tests used only the repository code (no external dependencies) and validated the new P1-ngram behavior and regression safety.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c3b581b4832889ec2d2d9e29f972)