### PR TITLE
Add Po_core API spec v1.0 and schema consistency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ print(result['summary'])
 | Philosophy Tensor v0.1 | ✅ Implemented | po_core_bridge: W_eth/T_free/T_sub/Po |
 | Interactive Simulator | ✅ Implemented | interactive_sim.py（外部依存なし） |
 | Business Demo | ✅ Implemented | demo_business.py（3シナリオ） |
-| Po_core 本格連携 | 🌱 Next Phase | bridge v0.1 は完成。API 仕様書を整備中 |
+| Po_core 本格連携 | ✅ v1.0 Spec Drafted | bridge v0.1 + API 仕様書 v1.0 + 契約整合テスト |
 
 **Completed Milestones (2026):**
 - [x] Verifiable Decision Layer v0.1 安定化（audit_log + 監査ハッシュ）
@@ -225,9 +225,9 @@ print(result['summary'])
 - [x] オフライン知識ベース（Privacy 準拠・Jaccard 類似検索・JSON 永続化）
 
 **Next Phase (Issues → `docs/next_issues.md`):**
-- [ ] Po_core 本格連携 API 仕様書 v1.0
-- [ ] meta_suggest の精度改善（No-Go チェックリスト誤検知修正）
-- [ ] check_reverse_manipulation の NLP 強化
+- [x] Po_core 本格連携 API 仕様書 v1.0
+- [x] meta_suggest の精度改善（No-Go チェックリスト誤検知修正）
+- [x] check_reverse_manipulation の NLP 強化
 - [ ] デモシナリオ追加（医療・教育・公共政策）
 
 ---

--- a/docs/api_spec_po_core_v1.md
+++ b/docs/api_spec_po_core_v1.md
@@ -1,0 +1,110 @@
+# Po_core 連携 API 仕様書 v1.0
+
+この文書は `bridge/po_core_bridge.py` が提供する統合 API の **安定仕様（v1.0）** を定義する。
+実装互換の基準は `get_tensor_schema()` の返却値とする。
+
+- 対象 API: `analyze_philosophy_tensor()` / `get_tensor_schema()`
+- 実装バージョン: `bridge_version = "v0.1"`
+- スキーマ識別子: `schema_version = "philosophy_tensor.v0.1"`
+
+## 1. エントリポイント
+
+### 1.1 `analyze_philosophy_tensor(...)`
+
+```python
+analyze_philosophy_tensor(
+    situation: str,
+    explanation: str = "",
+    human_decision: str = "",
+    existence_analysis: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]
+```
+
+### 1.2 `get_tensor_schema()`
+
+```python
+get_tensor_schema() -> Dict[str, Any]
+```
+
+## 2. 出力トップレベル契約
+
+- `schema_version: str`
+- `tensor: dict`
+  - `W_eth`, `T_free`, `T_sub`, `Po`
+- `summary: dict`
+- `disclaimer: str`
+- `po_core_compatibility: dict`
+
+## 3. テンソル成分契約（Canonical Snapshot）
+
+以下を **正（Canonical）** とする。
+
+<!-- tensor-schema:start -->
+```json
+{
+  "schema_version": "philosophy_tensor.v0.1",
+  "bridge_version": "v0.1",
+  "tensor_components": {
+    "W_eth": {
+      "required_fields": [
+        "conflict_codes",
+        "has_conflict",
+        "ensemble_majority",
+        "ensemble_minority_report",
+        "ensemble_votes",
+        "note"
+      ],
+      "description": "倫理テンソル: 哲学的矛盾検知 + アンサンブルレビュー"
+    },
+    "T_free": {
+      "required_fields": [
+        "tension_index",
+        "positions",
+        "synthesis_summary",
+        "open_questions_count",
+        "note"
+      ],
+      "description": "自由テンソル核: AI権利の未解決緊張"
+    },
+    "T_sub": {
+      "required_fields": [
+        "risk_level",
+        "direct_manipulation_blocked",
+        "direct_manipulation_hits",
+        "reverse_manipulation_warning",
+        "reverse_similarity_score",
+        "shared_tokens_sample",
+        "note"
+      ],
+      "description": "自己定義テンソル: 操作・逆算誘導リスク",
+      "risk_level_values": [
+        "block",
+        "warn",
+        "clear"
+      ]
+    },
+    "Po": {
+      "required_fields_if_available": [
+        "po_density",
+        "distortion_risk",
+        "lifecycle_judgment",
+        "affected_structures",
+        "note"
+      ],
+      "required_fields_always": [
+        "available",
+        "note"
+      ],
+      "description": "存在密度テンソル: 生存構造影響"
+    }
+  }
+}
+```
+<!-- tensor-schema:end -->
+
+## 4. 互換性ポリシー
+
+- `schema_version` の変更は **破壊的変更**。
+- `bridge_version` は実装配布識別子。
+- 新規フィールド追加は後方互換を維持する限り許容。
+- 破壊的変更時は本書とテストを同時更新する。

--- a/guideline.md
+++ b/guideline.md
@@ -203,6 +203,8 @@ python run_demo.py
 - [x] scripts/demo_business.py 追加（実ビジネスEnd-to-Endデモ: 3シナリオ・CLI対応）
 - [x] tests/test_po_core_bridge.py 追加（41件）
 - [x] tests/test_demo_business.py 追加（13件）
+- [x] docs/api_spec_po_core_v1.md 追加（Po_core 連携 API 仕様書 v1.0）
+- [x] tests/test_po_core_api_spec.py 追加（仕様書と get_tensor_schema() の契約整合）
 
 ## Next Phase Tasks（2026-03-09 session 19〜）
 - [x] scripts/interactive_sim.py 追加（インタラクティブ意思決定シミュレーター: input()ベース・外部依存なし）

--- a/progress_log.md
+++ b/progress_log.md
@@ -1,6 +1,28 @@
 # Progress Log
 > 各セッションの最後に追記（可能なら日付はJST、形式はYYYY-MM-DD）
 
+## 2026-03-14 (session 23 — Po_core API仕様書 v1.0 固定)
+
+### Goal
+- Po_core 本格連携に向けて API 仕様書 v1.0 を作成し、実装スキーマとの不一致を自動検知できる状態にする
+
+### Done
+- `docs/api_spec_po_core_v1.md`（新規）:
+  - `analyze_philosophy_tensor()` / `get_tensor_schema()` の契約を文書化
+  - Canonical Snapshot（JSON）を仕様の正として埋め込み
+  - 互換性ポリシー（schema_version の破壊的変更扱い）を明記
+- `tests/test_po_core_api_spec.py`（新規）:
+  - 仕様書内の Canonical Snapshot を抽出して `get_tensor_schema()` と完全一致を検証
+- `README.md`:
+  - Roadmap の Po_core 本格連携ステータスを更新
+  - Next Phase の 3項目（API仕様書 / meta_suggest 精度改善 / reverse_manipulation NLP強化）を done へ同期
+- `guideline.md`:
+  - Current Next Actions の完了項目に API仕様書v1.0 と契約整合テストを追記
+
+### Test Results
+- `python -m unittest -v tests.test_po_core_api_spec` → **1 test PASS**
+- `python -m unittest -v tests.test_po_core_bridge` → **34 tests PASS**
+
 ## 2026-03-14 (session 22 — reverse_manipulation P1-ngram 強化)
 
 ### Goal

--- a/tests/test_po_core_api_spec.py
+++ b/tests/test_po_core_api_spec.py
@@ -1,0 +1,28 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+from bridge.po_core_bridge import get_tensor_schema
+
+
+class TestPoCoreApiSpec(unittest.TestCase):
+    def test_api_spec_canonical_schema_matches_runtime_schema(self):
+        spec_path = Path("docs/api_spec_po_core_v1.md")
+        text = spec_path.read_text(encoding="utf-8")
+
+        match = re.search(
+            r"<!-- tensor-schema:start -->\s*```json\n(.*?)\n```\s*<!-- tensor-schema:end -->",
+            text,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(match, "canonical schema block not found in api_spec_po_core_v1.md")
+
+        canonical_schema = json.loads(match.group(1))
+        runtime_schema = get_tensor_schema()
+
+        self.assertEqual(canonical_schema, runtime_schema)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a stable, machine-checkable API specification for Po_core integration by documenting `analyze_philosophy_tensor()` / `get_tensor_schema()` and declaring a canonical schema snapshot. 
- Ensure implementation and documentation cannot drift by embedding a canonical JSON snapshot in the spec and verifying it against runtime output. 

### Description
- Added `docs/api_spec_po_core_v1.md` which documents the `analyze_philosophy_tensor()` / `get_tensor_schema()` contracts, embeds a canonical JSON schema snapshot, and states compatibility policy. 
- Added `tests/test_po_core_api_spec.py` which extracts the canonical snapshot from the spec and asserts it equals `get_tensor_schema()` at runtime. 
- Updated project tracking files (`README.md`, `guideline.md`, `progress_log.md`) to reflect that the Po_core API spec and related follow-ups are drafted and the new test was added. 

### Testing
- Ran `python -m unittest -v tests.test_po_core_api_spec` which passed (1 test OK). 
- Ran `python -m unittest -v tests.test_po_core_bridge` which passed (34 tests OK). 
- Executed `python scripts/meta_suggest.py 3` as a smoke check and it returned suggestions successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4daa26a7c832893b7ee5b425f6b95)