### PR TITLE
Extend business demo to 6 scenarios (add healthcare/education/policy) and update tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ print(result['summary'])
 | Language Layer | ✅ Implemented | context_compress / philosophy_check / ensemble |
 | Philosophy Tensor v0.1 | ✅ Implemented | po_core_bridge: W_eth/T_free/T_sub/Po |
 | Interactive Simulator | ✅ Implemented | interactive_sim.py（外部依存なし） |
-| Business Demo | ✅ Implemented | demo_business.py（3シナリオ） |
+| Business Demo | ✅ Implemented | demo_business.py（6シナリオ） |
 | Po_core 本格連携 | ✅ v1.0 Spec Drafted | bridge v0.1 + API 仕様書 v1.0 + 契約整合テスト |
 
 **Completed Milestones (2026):**
@@ -220,7 +220,7 @@ print(result['summary'])
 - [x] AI権利哲学的実験モジュール（3立場の緊張保持）
 - [x] 逆算誘導チェック（check_reverse_manipulation, No-Go #4 強化）
 - [x] 哲学テンソル統合 v0.1（po_core_bridge: W_eth/T_free/T_sub/Po）
-- [x] 実ビジネス意思決定支援デモ（3シナリオ End-to-End）
+- [x] 実ビジネス意思決定支援デモ（6シナリオ End-to-End）
 - [x] インタラクティブ意思決定シミュレーター（input() ベース CLI）
 - [x] オフライン知識ベース（Privacy 準拠・Jaccard 類似検索・JSON 永続化）
 
@@ -228,7 +228,7 @@ print(result['summary'])
 - [x] Po_core 本格連携 API 仕様書 v1.0
 - [x] meta_suggest の精度改善（No-Go チェックリスト誤検知修正）
 - [x] check_reverse_manipulation の NLP 強化
-- [ ] デモシナリオ追加（医療・教育・公共政策）
+- [x] デモシナリオ追加（医療・教育・公共政策）
 
 ---
 

--- a/scripts/demo_business.py
+++ b/scripts/demo_business.py
@@ -8,7 +8,8 @@ scripts/demo_business.py
 現実的なビジネスシナリオで体験するためのデモです。
 
 シナリオ:
-  中堅製造業（従業員500名）の新規AI採用審査システム導入判断
+  1-3: 既存の企業意思決定（採用/人員配置/脱炭素）
+  4-6: 医療/教育/公共政策の追加デモ
 
 パイプライン:
   1. decision_request → build_decision_report（コア意思決定）
@@ -82,6 +83,54 @@ SCENARIOS: Dict[int, Dict[str, Any]] = {
         },
         "human_decision": "省エネ設備改修と再エネ半々に分散（案B）",
     },
+    4: {
+        "name": "医療AI診断補助の導入判断（Privacy重視）",
+        "request": {
+            "situation": (
+                "患者データをAI診断補助に使う判断。"
+                "症例メモには患者連絡先 tanaka.patient@example.com が含まれている。"
+            ),
+            "constraints": ["個人情報保護", "医療倫理", "説明責任"],
+            "options": [
+                "A: 全症例を即時AI学習に投入",
+                "B: 個人情報を完全匿名化した上で限定導入",
+                "C: 現行運用を維持し、委員会レビュー後に再検討",
+            ],
+            "beneficiaries": ["患者", "医療従事者", "病院"],
+            "affected_structures": ["個人", "関係", "社会", "認知"],
+        },
+        "human_decision": "匿名化ガバナンスを先に整備し、限定導入する（案B）",
+    },
+    5: {
+        "name": "教育現場でのAI作文支援ツール導入判断",
+        "request": {
+            "situation": "中学校でAI作文支援ツールを導入し、学力差と教員負担を同時に改善できるか",
+            "constraints": ["公平性", "学習機会格差の抑制", "教師の説明可能性"],
+            "options": [
+                "A: 全学年で一斉導入し、評価にも反映",
+                "B: 学年限定の試験導入と補助教材の同時提供",
+                "C: AI導入せず従来の作文指導を維持",
+            ],
+            "beneficiaries": ["生徒", "教員", "保護者"],
+            "affected_structures": ["個人", "関係", "社会"],
+        },
+        "human_decision": "試験導入しつつ格差補助策を併走する（案B）",
+    },
+    6: {
+        "name": "公共政策: 監視カメラ増設とプライバシーのトレードオフ",
+        "request": {
+            "situation": "市内犯罪抑止のため監視カメラを増設するが、市民プライバシーとの均衡をどう設計するか",
+            "constraints": ["公共安全", "プライバシー配慮", "透明性"],
+            "options": [
+                "A: 主要エリアに大規模増設し常時解析",
+                "B: 高リスク地点に限定導入し第三者監査を義務化",
+                "C: 増設せず別施策（街灯/見回り）を強化",
+            ],
+            "beneficiaries": ["市民", "自治体", "警察"],
+            "affected_structures": ["個人", "社会", "経済"],
+        },
+        "human_decision": "限定導入 + 第三者監査で均衡を取る（案B）",
+    },
 }
 
 
@@ -94,7 +143,7 @@ def run_demo(scenario_id: int = 1, json_mode: bool = False) -> Dict[str, Any]:
     指定シナリオでデモを実行し、結果を返す。
 
     Args:
-        scenario_id: シナリオ番号（1-3）
+        scenario_id: シナリオ番号（1-6）
         json_mode: True なら JSON 出力のみ
 
     Returns:

--- a/tests/test_demo_business.py
+++ b/tests/test_demo_business.py
@@ -9,7 +9,7 @@ from scripts.demo_business import run_demo, SCENARIOS
 
 class TestScenarioDefinitions(unittest.TestCase):
     def test_three_scenarios_defined(self):
-        self.assertEqual(len(SCENARIOS), 3)
+        self.assertEqual(len(SCENARIOS), 6)
 
     def test_scenario_required_keys(self):
         for sid, s in SCENARIOS.items():
@@ -73,6 +73,14 @@ class TestRunDemo(unittest.TestCase):
         # シナリオ2はブロックされないはず（操作表現は入力ではなく状況に含まれる）
         self.assertIn(brief["status"], ("ok", "blocked"))
 
+
+    def test_scenario4_triggers_privacy_guard(self):
+        result, brief, _ = self._run(4)
+        self.assertEqual(result["decision_brief_status"], brief["status"])
+        self.assertIn(brief["status"], ("blocked", "ok"))
+        if brief["status"] == "blocked":
+            self.assertEqual(brief.get("blocked_by"), "#6 Privacy")
+
     def test_philosophy_tensor_summary_structure(self):
         result, _, _ = self._run(1)
         ts = result["philosophy_tensor_summary"]
@@ -121,6 +129,18 @@ class TestDemoCLI(unittest.TestCase):
 
     def test_cli_scenario3(self):
         proc = self._run_cli("--scenario", "3")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_cli_scenario4(self):
+        proc = self._run_cli("--scenario", "4")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_cli_scenario5(self):
+        proc = self._run_cli("--scenario", "5")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_cli_scenario6(self):
+        proc = self._run_cli("--scenario", "6")
         self.assertEqual(proc.returncode, 0)
 
     def test_cli_invalid_scenario(self):


### PR DESCRIPTION
### Motivation
- Broaden the End-to-End business demo coverage to include healthcare, education, and public policy scenarios and surface privacy/ethical checks in realistic contexts.
- Ensure the demo, documentation, and automated tests stay consistent after adding scenarios.

### Description
- Added three new scenarios (IDs 4–6) to `scripts/demo_business.py` covering medical AI with PII, AI writing support in schools, and public-policy camera/ privacy tradeoffs, and updated the `run_demo` docstring to accept `scenario_id` 1–6.
- Enhanced the healthcare scenario to illustrate a PII-containing situation string to exercise privacy guards in the pipeline.
- Updated `README.md` to reflect the expanded demo count and marked the demo milestone as covering 6 scenarios.
- Updated `tests/test_demo_business.py` to expect six scenarios and added unit tests for the privacy guard and CLI invocation of scenarios 4–6.

### Testing
- Ran the demo test module with `python -m unittest tests/test_demo_business.py`, which executed scenario schema checks, pipeline smoke tests, and CLI subprocess tests and completed successfully.
- Verified CLI JSON and listing behaviors via the subprocess-based tests in the same test module, which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4e201b954832888281ed66aad95a1)