### PR TITLE
interactive_sim: add persistent KB support, interactive save prompt, and early similar-results display

### DIFF
--- a/scripts/interactive_sim.py
+++ b/scripts/interactive_sim.py
@@ -168,6 +168,12 @@ def display_result(
     knowledge_similar: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
     """分析結果を人間が読みやすい形式で表示する。"""
+    if knowledge_similar:
+        _print_section("過去類似決定（参考）")
+        for i, past in enumerate(knowledge_similar[:3], 1):
+            print(f"  [{i}] {past['timestamp_utc'][:10]} | {past['status']} "
+                  f"| {past['reason_codes']} | 類似度 {past['similarity']:.2f}")
+
     _print_section("意思決定ブリーフ")
     status = brief.get("status")
     print(f"  status: {status}")
@@ -214,12 +220,6 @@ def display_result(
     if t_sub.get("reverse_manipulation_warning"):
         print(f"  ⚠ 逆算誘導警告（スコア {t_sub['reverse_similarity_score']:.2f}）")
 
-    if knowledge_similar:
-        _print_section("過去類似決定（参考）")
-        for i, past in enumerate(knowledge_similar[:3], 1):
-            print(f"  [{i}] {past['timestamp_utc'][:10]} | {past['status']} "
-                  f"| {past['reason_codes']} | 類似度 {past['similarity']:.2f}")
-
     print(f"\n{_SEPARATOR}")
     print(f"  {_DISCLAIMER}")
     print(_SEPARATOR)
@@ -234,6 +234,7 @@ def run_simulation(
     json_mode: bool = False,
     stdin: IO[str] = None,
     record_to_kb: bool = True,
+    kb_path: str = "",
 ) -> Dict[str, Any]:
     """
     シミュレーションを実行して結果を返す。
@@ -296,19 +297,28 @@ def run_simulation(
     )
 
     # Step 5: 知識ベース（類似検索 + 記録）
-    kb = KnowledgeBase()
+    kb = KnowledgeBase(path=kb_path or None)
     similar = []
     if record_to_kb:
         reason_codes = []
         if brief["status"] == "ok":
             reason_codes = brief.get("selection", {}).get("reason_codes", [])
         similar = kb.find_similar(reason_codes, top_k=3)
-        kb.record(
-            decision_hash=entry.decision_hash,
-            status=brief["status"],
-            reason_codes=reason_codes,
-            blocked_by=brief.get("blocked_by"),
-        )
+        save_to_kb = True
+        if not auto:
+            answer = _prompt("\n今回の決定を KB に保存しますか？ (Y/n)", default="Y", stdin=stdin)
+            save_to_kb = answer.strip().lower() not in ("n", "no")
+
+        if save_to_kb:
+            kb.record(
+                decision_hash=entry.decision_hash,
+                status=brief["status"],
+                reason_codes=reason_codes,
+                blocked_by=brief.get("blocked_by"),
+            )
+            record_to_kb = True
+        else:
+            record_to_kb = False
 
     # Step 6: 表示 or JSON 出力
     if not json_mode:
@@ -344,6 +354,11 @@ def main() -> int:
         "--no-kb", action="store_true",
         help="知識ベースへの記録をスキップする",
     )
+    parser.add_argument(
+        "--kb-path",
+        default="",
+        help="知識ベースJSONの保存/読込パス（未指定時はインメモリ）",
+    )
     args = parser.parse_args()
 
     try:
@@ -351,6 +366,7 @@ def main() -> int:
             auto=args.auto,
             json_mode=args.json,
             record_to_kb=not args.no_kb,
+            kb_path=args.kb_path,
         )
     except KeyboardInterrupt:
         print("\n\n  中断しました。またいつでも使ってください。")

--- a/tests/test_interactive_sim.py
+++ b/tests/test_interactive_sim.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 
 
@@ -100,6 +101,25 @@ class TestRunSimulation(unittest.TestCase):
         result = run_simulation(auto=True, json_mode=True, record_to_kb=False)
         self.assertFalse(result["knowledge_recorded"])
 
+    def test_kb_path_persists_records(self):
+        from scripts.interactive_sim import run_simulation
+        with tempfile.TemporaryDirectory() as td:
+            kb_path = os.path.join(td, "kb.json")
+            result = run_simulation(
+                auto=True,
+                json_mode=True,
+                record_to_kb=True,
+                kb_path=kb_path,
+            )
+            self.assertTrue(result["knowledge_recorded"])
+            self.assertTrue(os.path.isfile(kb_path))
+
+    def test_interactive_decline_kb_record(self):
+        from scripts.interactive_sim import run_simulation
+        stdin = io.StringIO("\n\n\n\n\nN\n")
+        result = run_simulation(auto=False, json_mode=True, stdin=stdin, record_to_kb=True)
+        self.assertFalse(result["knowledge_recorded"])
+
 
 class TestInteractiveSimCLI(unittest.TestCase):
     """CLI の動作テスト（サブプロセスで実行）"""
@@ -136,6 +156,13 @@ class TestInteractiveSimCLI(unittest.TestCase):
     def test_no_kb_flag(self):
         proc = self._run("--auto", "--no-kb")
         self.assertEqual(proc.returncode, 0)
+
+    def test_kb_path_flag(self):
+        with tempfile.TemporaryDirectory() as td:
+            kb_path = os.path.join(td, "cli_kb.json")
+            proc = self._run("--auto", "--kb-path", kb_path)
+            self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+            self.assertTrue(os.path.isfile(kb_path))
 
     def test_audit_hash_in_output(self):
         proc = self._run("--auto")


### PR DESCRIPTION
### Motivation
- Make `interactive_sim` integrate more usefully with the offline knowledge base by allowing persistent storage and letting users opt out of recording decisions. 
- Surface similar past decisions earlier in the UI so users can reference prior context before reading the decision brief.

### Description
- Added a `kb_path` argument to `run_simulation()` and a `--kb-path` CLI flag to load/save a persistent KB JSON via `KnowledgeBase(path=...)`.
- Added an interactive confirmation prompt `今回の決定を KB に保存しますか？ (Y/n)` in non-auto mode that skips recording when the user answers `N`/`no`.
- Show `knowledge_similar` results at the start of `display_result()` so past similar decisions are printed before the decision brief.
- Extended `tests/test_interactive_sim.py` with tests for KB persistence, interactive decline of KB recording, and the CLI `--kb-path` behavior.

### Testing
- Ran the targeted test suite with `python -m unittest -v tests/test_interactive_sim.py tests/test_demo_business.py tests/test_meta_suggest.py` and all tests passed.
- Total executed tests: 61, all succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4e96947e88328bdd55dfbc62348b6)