### PR TITLE
chore: sync completed backlog items in idea_note.md and record session in progress_log.md

### DIFF
--- a/idea_note.md
+++ b/idea_note.md
@@ -50,24 +50,25 @@
   - Notes: scripts/validate_request.py + aicw/schema.py として実装済み（exit code 0/1/2）
   - Status: done
 
-- [ ] (2026-02-22) Idea: Markdown入力アダプタ（Markdown→decision_request.v0 JSON変換）を後付けする
+- [x] (2026-02-22) Idea: Markdown入力アダプタ（Markdown→decision_request.v0 JSON変換）を後付けする
   - Source: AI
   - Why: JSON編集が苦手でも使えるようにする（ただしcanonicalはJSONのまま）
-  - Notes: 契約は壊さず”入口を増やす”だけ
-  - Status: backlog → 実装予定（session 9）
+  - Notes: `scripts/md_adapter.py` + `tests/test_md_adapter.py` として実装済み。契約（decision_request.v0）を維持したまま入口のみ追加
+  - Status: done
 
-- [ ] (2026-02-22) Idea:リスクと改善提案
+- [x] (2026-02-22) Idea:リスクと改善提案
 　- 誤検知の扱い
-　- 現状は全て severity="block" で止める設計。運用では warn と block を分け、人間の確認フローを入れると安全です。
+　- 現状は全て severity="block" で止める設計。運用では warn と block を分け、人間の確認フローを入れると安全です。（対応済み: `aicw/safety.py` で warn/block 段階化）
 　- 正規表現の脆弱性
 　- 例えばメールの正規表現は簡易版で、RFC準拠ではない。重要用途なら既存ライブラリや成熟したPII検出ライブラリを検討してください。
 　- コンテキスト判定の欠如
-　- scan_manipulation のような単純一致は文脈を無視するため、誤検知が多い。NLPベースの文脈判定（軽量モデルやルール＋スコアリング）を組み合わせると精度が上がります。
+　- scan_manipulation のような単純一致は文脈を無視するため、誤検知が多い。NLPベースの文脈判定（軽量モデルやルール＋スコアリング）を組み合わせると精度が上がります。（対応済み: スコアリング化 + reverse_manipulation を `P1-ngram` へ強化）
 　- 監査ログとメタ情報
-　- 何を検出したか（中身は保存しない）・いつ誰がブロックしたか等の監査ログを残す仕組みを入れると運用上安心です。
+　- 何を検出したか（中身は保存しない）・いつ誰がブロックしたか等の監査ログを残す仕組みを入れると運用上安心です。（対応済み: `aicw/audit_log.py`）
 　- テストカバレッジ
-　- 正規表現ごとに正例・負例のユニットテストを用意し、誤検知率を定量化して閾値を決めるべ
+　- 正規表現ごとに正例・負例のユニットテストを用意し、誤検知率を定量化して閾値を決めるべ（対応済み: 関連ユニットテスト拡充）
 　- きです。
+  - Status: done（主要提案は実装反映済み）
 
 - [ ] 具体的な小さな改善コード例（方針のみ）
 　- Finding.severity をルールごとに設定可能にする（現在は固定）。

--- a/progress_log.md
+++ b/progress_log.md
@@ -904,3 +904,18 @@ impact_score = min(構造層数 + risk_bonus, 8) ／ threshold=6 で A にオー
 ### Test Results
 - `python -m unittest -v tests.test_meta_suggest` PASS
 - `python -m unittest discover -s tests -v` PASS
+
+## 2026-03-14 (session 24 — Backlog同期: idea_note の実装済み項目を反映)
+
+### Goal
+- `idea_note.md` に残っていた古い未完了チェックを、実装済み状態へ同期する
+- `meta_suggest` の次タスク候補が実態に近い内容になるように backlog 精度を改善する
+
+### Done
+- `idea_note.md` を更新:
+  - 「Markdown入力アダプタ」を `done` に更新（`scripts/md_adapter.py` / `tests/test_md_adapter.py` 実装済みを反映）
+  - 「リスクと改善提案」を `done` に更新し、対応済み実装（warn/block 段階化、監査ログ、reverse_manipulation 強化）を注記
+
+### Test Results
+- `PYTHONPATH=. python scripts/meta_suggest.py 3` で候補の変化を確認
+- `PYTHONPATH=. pytest -q tests/test_meta_suggest.py` → **15 tests PASS**


### PR DESCRIPTION
### Motivation

- Prevent `scripts/meta_suggest.py` from surfacing backlog items that are already implemented by marking them done in the canonical notes. 
- Record the backlog-sync operation and its validation in `progress_log.md` so the repository history and suggestion output remain consistent.

### Description

- Update `idea_note.md` to mark the Markdown input adapter idea as completed and annotate it with the implemented artifacts (`scripts/md_adapter.py` and `tests/test_md_adapter.py`).
- Update `idea_note.md` to mark the "リスクと改善提案" entry as done and annotate it with implemented mitigations (warn/block staging in `aicw/safety.py`, reverse-manipulation `P1-ngram` note, and `aicw/audit_log.py`).
- Append a new session entry (session 24) to `progress_log.md` documenting the backlog-sync goal, actions, and validation commands.
- Commit the changes (files changed: `idea_note.md`, `progress_log.md`).

### Testing

- Ran `PYTHONPATH=. python scripts/meta_suggest.py 3` and confirmed the suggestion list changed to reflect the synced backlog (total candidates reduced accordingly). 
- Ran `PYTHONPATH=. pytest -q tests/test_meta_suggest.py` and observed all tests passed (`15 tests PASS`).
- All changes were committed locally (`chore: sync completed backlog items in idea notes`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b52c794a188328a40634d227017c91)