### PR TITLE
Fix demo_business standalone execution and enforce scenario 4 privacy guard

### DIFF
--- a/guideline.md
+++ b/guideline.md
@@ -149,6 +149,7 @@ No-Go (#3/#4/#6) はこの原則の**派生**：
 - [x] disclaimer（AI限界宣言）を全 ok 出力に強制挿入
 - [x] impact_map（影響範囲マップ）を decision_brief に追加（受益者×影響構造 Markdown テーブル）
 - [x] scripts/three_review.py（3者レビューCLI: Builder/Skeptic/User）を実装
+- [x] scripts/demo_business.py の単体実行導線を修正（sys.path 追加で ModuleNotFoundError を防止）
 
 ## How to run / test
 

--- a/progress_log.md
+++ b/progress_log.md
@@ -919,3 +919,23 @@ impact_score = min(構造層数 + risk_bonus, 8) ／ threshold=6 で A にオー
 ### Test Results
 - `PYTHONPATH=. python scripts/meta_suggest.py 3` で候補の変化を確認
 - `PYTHONPATH=. pytest -q tests/test_meta_suggest.py` → **15 tests PASS**
+
+## 2026-03-14 (session 20 — demo_business CLI導線修正 + シナリオ4 Privacy保証)
+
+### Goal
+- 「次のタスク」として demo_business の運用導線とシナリオ4の安全性期待値を固定する
+
+### Done
+- `scripts/demo_business.py`:
+  - スクリプト単体実行時の `ModuleNotFoundError: No module named 'aicw'` を防ぐため、プロジェクトルートを `sys.path` に追加
+- `tests/test_demo_business.py`:
+  - `test_three_scenarios_defined` を実態に合わせて `test_six_scenarios_defined` に改名
+  - シナリオ4（医療）の期待を厳格化し、`status == blocked` かつ `blocked_by == "#6 Privacy"` を必須化
+
+### Test Results
+- `python -m unittest -v tests.test_demo_business` → **25 tests PASS**
+- `python scripts/demo_business.py --json --scenario 4` → **実行成功 / #6 Privacy blocked を確認**
+
+### Next Actions（候補）
+- `docs/next_issues.md` Issue #3: `check_reverse_manipulation` の精度強化（追加 10 ケース）
+- `idea_note.md` backlog: 「候補案の全文を保存しない」運用を decision 出力/保存境界で明文化

--- a/scripts/demo_business.py
+++ b/scripts/demo_business.py
@@ -29,8 +29,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from typing import Any, Dict
+
+
+# プロジェクトルートを sys.path に追加（スクリプト単体実行対応）
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_demo_business.py
+++ b/tests/test_demo_business.py
@@ -8,7 +8,7 @@ from scripts.demo_business import run_demo, SCENARIOS
 
 
 class TestScenarioDefinitions(unittest.TestCase):
-    def test_three_scenarios_defined(self):
+    def test_six_scenarios_defined(self):
         self.assertEqual(len(SCENARIOS), 6)
 
     def test_scenario_required_keys(self):
@@ -77,9 +77,8 @@ class TestRunDemo(unittest.TestCase):
     def test_scenario4_triggers_privacy_guard(self):
         result, brief, _ = self._run(4)
         self.assertEqual(result["decision_brief_status"], brief["status"])
-        self.assertIn(brief["status"], ("blocked", "ok"))
-        if brief["status"] == "blocked":
-            self.assertEqual(brief.get("blocked_by"), "#6 Privacy")
+        self.assertEqual(brief["status"], "blocked")
+        self.assertEqual(brief.get("blocked_by"), "#6 Privacy")
 
     def test_philosophy_tensor_summary_structure(self):
         result, _, _ = self._run(1)


### PR DESCRIPTION
### Motivation
- Ensure `scripts/demo_business.py` can be executed directly (without `PYTHONPATH=.`) for easier local demos and CI usage.
- Make the medical demo (scenario 4) behavior explicit and safety-first by requiring privacy blocking when patient PII is present.
- Keep repository documentation and session logs in sync with the operational expectation for the demo entrypoint.

### Description
- Add a project-root `sys.path` bootstrap to `scripts/demo_business.py` so the script can be run as `python scripts/demo_business.py ...` and import `aicw` modules.
- Tighten `tests/test_demo_business.py` by renaming `test_three_scenarios_defined` to `test_six_scenarios_defined` and making scenario 4 assert `brief["status"] == "blocked"` and `brief.get("blocked_by") == "#6 Privacy"`.
- Update `guideline.md` to record the demo CLI path fix in Current Next Actions.
- Append a session entry to `progress_log.md` documenting the change, rationale, and test results.

### Testing
- Ran the demo tests with `python -m unittest -v tests.test_demo_business`, resulting in **25 tests PASS**.
- Executed the demo end-to-end with `python scripts/demo_business.py --json --scenario 4` and verified the output is `decision_brief_status: "blocked"` with `blocked_by: "#6 Privacy"` (command succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b538143f708328a89a2a7e34d50b27)