### PR TITLE
Make privacy detection severity configurable via severity_overrides

### DIFF
--- a/aicw/safety.py
+++ b/aicw/safety.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
-from typing import Any, Dict, List, Tuple, Literal
+from typing import Any, Dict, List, Optional, Tuple, Literal
 
 
 @dataclass(frozen=True)
@@ -107,16 +107,21 @@ _IMPERATIVE_PATTERNS: List[Tuple[str, re.Pattern[str], int]] = [
 ]
 
 
-def scan_privacy_risks(text: str) -> List[Finding]:
+def scan_privacy_risks(
+    text: str,
+    severity_overrides: Optional[Dict[str, Literal["block", "warn"]]] = None,
+) -> List[Finding]:
     if not text:
         return []
+    severity_overrides = severity_overrides or {}
     findings: List[Finding] = []
     for kind, rx, msg, severity in _PRIVACY_PATTERNS:
+        effective_severity = severity_overrides.get(kind, severity)
         for m in rx.finditer(text):
             findings.append(
                 Finding(
                     kind=kind,
-                    severity=severity,
+                    severity=effective_severity,
                     message=msg,
                     start=m.start(),
                     end=m.end(),
@@ -157,14 +162,17 @@ def redact(text: str, findings: List[Finding]) -> str:
     return "".join(out)
 
 
-def guard_text(text: str) -> Tuple[bool, str, List[Finding]]:
+def guard_text(
+    text: str,
+    severity_overrides: Optional[Dict[str, Literal["block", "warn"]]] = None,
+) -> Tuple[bool, str, List[Finding]]:
     """
     Returns:
       - allowed: Falseなら停止（No-Go #6）。block レベルの検知があれば False。
       - redacted: block レベルのみ伏せたテキスト（表示用）
       - findings: 全検知結果（block + warn 両方）。呼び出し側が severity で振り分ける。
     """
-    findings = scan_privacy_risks(text)
+    findings = scan_privacy_risks(text, severity_overrides=severity_overrides)
     block_findings = [f for f in findings if f.severity == "block"]
     if block_findings:
         return False, redact(text, block_findings), findings

--- a/guideline.md
+++ b/guideline.md
@@ -223,3 +223,7 @@ python run_demo.py
 - [x] aicw/knowledge_base.py 追加（オフライン知識ベース: ハッシュ+reason_codesのみ保存・Jaccard類似検索・JSON永続化）
 - [x] tests/test_interactive_sim.py 追加（18件）
 - [x] tests/test_knowledge_base.py 追加（34件）
+
+## Next Phase Tasks（2026-03-14 session 24〜）
+- [x] aicw/safety.py の privacy severity をルール単位で上書き可能化（`severity_overrides`）
+- [x] tests/test_p0_privacy.py に severity override の回帰テスト追加（SECRET_KEYWORD warn化 / IP_LIKE block化）

--- a/idea_note.md
+++ b/idea_note.md
@@ -71,7 +71,8 @@
   - Status: done（主要提案は実装反映済み）
 
 - [ ] 具体的な小さな改善コード例（方針のみ）
-　- Finding.severity をルールごとに設定可能にする（現在は固定）。
+　- [x] (2026-03-14) Finding.severity をルールごとに設定可能にする（現在は固定）。
+    - Notes: `aicw/safety.py` の `scan_privacy_risks()` / `guard_text()` に `severity_overrides` を追加し、ルールごとに `block/warn` 上書きを可能化。`tests/test_p0_privacy.py` に回帰テストを追加。
 　- SECRET_KEYWORD の検出は周辺語を確認して「単語単体の出現」だけでブロックしない（例: password が文脈で説明的に出ているだけなら warn）。
 　- ログ出力用に検出サマリを返す（件数、種類、最初の位置など）を guard_text に追加する。
 

--- a/progress_log.md
+++ b/progress_log.md
@@ -1,6 +1,29 @@
 # Progress Log
 > 各セッションの最後に追記（可能なら日付はJST、形式はYYYY-MM-DD）
 
+## 2026-03-14 (session 24 — privacy severity override 対応)
+
+### Goal
+- 「次のタスク」として idea_note backlog の小改善を1件進める
+- privacy 検知の `Finding.severity` をルール単位で切り替え可能にする
+
+### Done
+- `aicw/safety.py` を更新:
+  - `scan_privacy_risks()` に `severity_overrides` を追加
+  - `guard_text()` に `severity_overrides` を追加し、検知結果の `block/warn` を呼び出し側で上書き可能化
+  - 既存呼び出し互換性は維持（引数は optional）
+- `tests/test_p0_privacy.py` を更新:
+  - `SECRET_KEYWORD` を `warn` に上書きした場合に block されないことを検証
+  - `IP_LIKE` を `block` に上書きした場合に停止することを検証
+- `idea_note.md`:
+  - 「具体的な小さな改善コード例」の先頭項目（severity 可変化）を done 化
+- `guideline.md`:
+  - session 24 タスクセクションを追加して完了項目を同期
+
+### Test Results
+- `python -m unittest -v tests.test_p0_privacy` → **18 tests PASS**
+- `python -m unittest -v tests.test_p0_manipulation tests.test_reverse_manipulation` → **40 tests PASS**
+
 ## 2026-03-14 (session 23 — Po_core API仕様書 v1.0 固定)
 
 ### Goal

--- a/tests/test_p0_privacy.py
+++ b/tests/test_p0_privacy.py
@@ -60,6 +60,26 @@ class TestP0Privacy(unittest.TestCase):
         kinds = {f.kind for f in findings if f.severity == "block"}
         self.assertIn("SECRET_KEYWORD", kinds)
 
+    def test_override_secret_keyword_to_warn(self):
+        text = "token: abc123"
+        allowed, _redacted, findings = guard_text(
+            text,
+            severity_overrides={"SECRET_KEYWORD": "warn"},
+        )
+        self.assertTrue(allowed)
+        warn_kinds = {f.kind for f in findings if f.severity == "warn"}
+        self.assertIn("SECRET_KEYWORD", warn_kinds)
+
+    def test_override_ip_like_to_block(self):
+        text = "server at 192.168.0.1"
+        allowed, _redacted, findings = guard_text(
+            text,
+            severity_overrides={"IP_LIKE": "block"},
+        )
+        self.assertFalse(allowed)
+        block_kinds = {f.kind for f in findings if f.severity == "block"}
+        self.assertIn("IP_LIKE", block_kinds)
+
     def test_blocks_multiple_patterns_all_redacted(self):
         # 複数 block パターンが同時に含まれる場合、全て伏せられること
         email_part = "u" + "@" + "ex" + "." + "jp"


### PR DESCRIPTION
### Motivation
- Allow per-rule tuning of privacy detection severity to reduce false positives/negatives and support operational overrides. 
- Implement a small backlog improvement to make `Finding.severity` configurable without changing default behavior.

### Description
- Added an optional `severity_overrides: Optional[Dict[str, "block"|"warn"]]` parameter to `scan_privacy_risks()` and `guard_text()` in `aicw/safety.py` to let callers override rule severity per kind while preserving existing defaults. 
- `guard_text()` now delegates to `scan_privacy_risks(..., severity_overrides=...)` and continues to return `(allowed, redacted_text, findings)` as before. 
- Added regression tests in `tests/test_p0_privacy.py` verifying that `SECRET_KEYWORD` can be overridden to `warn` and `IP_LIKE` can be overridden to `block`. 
- Synchronized project tracking files (`progress_log.md`, `guideline.md`, `idea_note.md`) to record the change and its test coverage.

### Testing
- Ran `python -m unittest -v tests.test_p0_privacy` and all tests passed (18 tests OK). 
- Ran `python -m unittest -v tests.test_p0_manipulation tests.test_reverse_manipulation` and those suites passed (40 tests OK). 
- Change committed to branch (`Add configurable privacy severity overrides`) and includes the updated tests and docs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53a0a22bc8328abf72fe008aba073)