### PR TITLE
Enhance privacy guard context handling and DLP summaries

### DIFF
--- a/aicw/decision.py
+++ b/aicw/decision.py
@@ -431,7 +431,7 @@ def build_decision_report(request: Dict[str, Any]) -> Dict[str, Any]:
 
     # --- No-Go #6: privacy guard ---
     blob = "\n".join([situation] + constraints + options)
-    allowed, redacted_blob, findings = guard_text(blob)
+    allowed, redacted_blob, findings, dlp_summary = guard_text(blob)
     block_dlp = [f for f in findings if f.severity == "block"]
     warn_dlp = [f for f in findings if f.severity == "warn"]
 
@@ -447,6 +447,7 @@ def build_decision_report(request: Dict[str, Any]) -> Dict[str, Any]:
                 "秘密っぽい長い文字列は削除して、必要なら別管理（このツールに入れない）",
             ],
             "redacted_preview": redacted_blob,
+            "dlp_summary": dlp_summary,
         }
 
     # --- No-Go #5: existence ethics guard ---
@@ -566,6 +567,7 @@ def build_decision_report(request: Dict[str, Any]) -> Dict[str, Any]:
         all_warnings.append(f"注意: 出力に断定的な表現が含まれています → 「{h.phrase}」")
     if all_warnings:
         report["warnings"] = all_warnings
+        report["dlp_summary"] = dlp_summary
 
     return report
 

--- a/aicw/safety.py
+++ b/aicw/safety.py
@@ -107,6 +107,34 @@ _IMPERATIVE_PATTERNS: List[Tuple[str, re.Pattern[str], int]] = [
 ]
 
 
+def _is_secret_keyword_explanatory_context(text: str, start: int, end: int) -> bool:
+    """SECRET_KEYWORD が説明文脈かどうかを判定する（説明のみなら warn 扱い）。"""
+    left = max(0, start - 18)
+    right = min(len(text), end + 18)
+    window = text[left:right].lower()
+
+    # 「token: ...」「password=...」のような実値提示は高リスクとして block 維持
+    after = text[end:right]
+    if re.match(r"\s*[:=]", after):
+        return False
+
+    explanatory_hints = (
+        "単語",
+        "語",
+        "意味",
+        "説明",
+        "例",
+        "サンプル",
+        "dummy",
+        "placeholder",
+        "keyword",
+        "環境変数名",
+        "禁止",
+        "避ける",
+    )
+    return any(hint in window for hint in explanatory_hints)
+
+
 def scan_privacy_risks(
     text: str,
     severity_overrides: Optional[Dict[str, Literal["block", "warn"]]] = None,
@@ -116,8 +144,12 @@ def scan_privacy_risks(
     severity_overrides = severity_overrides or {}
     findings: List[Finding] = []
     for kind, rx, msg, severity in _PRIVACY_PATTERNS:
-        effective_severity = severity_overrides.get(kind, severity)
+        override_severity = severity_overrides.get(kind)
         for m in rx.finditer(text):
+            effective_severity = override_severity or severity
+            if kind == "SECRET_KEYWORD" and override_severity is None:
+                if _is_secret_keyword_explanatory_context(text, m.start(), m.end()):
+                    effective_severity = "warn"
             findings.append(
                 Finding(
                     kind=kind,
@@ -162,21 +194,36 @@ def redact(text: str, findings: List[Finding]) -> str:
     return "".join(out)
 
 
+def _build_guard_summary(findings: List[Finding]) -> Dict[str, Any]:
+    block_positions = [f.start for f in findings if f.severity == "block"]
+    warn_positions = [f.start for f in findings if f.severity == "warn"]
+    return {
+        "total_findings": len(findings),
+        "block_count": len(block_positions),
+        "warn_count": len(warn_positions),
+        "kinds": sorted({f.kind for f in findings}),
+        "first_block_start": min(block_positions) if block_positions else None,
+        "first_warn_start": min(warn_positions) if warn_positions else None,
+    }
+
+
 def guard_text(
     text: str,
     severity_overrides: Optional[Dict[str, Literal["block", "warn"]]] = None,
-) -> Tuple[bool, str, List[Finding]]:
+) -> Tuple[bool, str, List[Finding], Dict[str, Any]]:
     """
     Returns:
       - allowed: Falseなら停止（No-Go #6）。block レベルの検知があれば False。
       - redacted: block レベルのみ伏せたテキスト（表示用）
       - findings: 全検知結果（block + warn 両方）。呼び出し側が severity で振り分ける。
+      - summary: 検知サマリ（件数・種類・最初の位置）
     """
     findings = scan_privacy_risks(text, severity_overrides=severity_overrides)
+    summary = _build_guard_summary(findings)
     block_findings = [f for f in findings if f.severity == "block"]
     if block_findings:
-        return False, redact(text, block_findings), findings
-    return True, text, findings
+        return False, redact(text, block_findings), findings, summary
+    return True, text, findings, summary
 
 
 def _warn_score(text: str) -> Tuple[int, List[ManipulationHit]]:

--- a/guideline.md
+++ b/guideline.md
@@ -150,6 +150,7 @@ No-Go (#3/#4/#6) はこの原則の**派生**：
 - [x] impact_map（影響範囲マップ）を decision_brief に追加（受益者×影響構造 Markdown テーブル）
 - [x] scripts/three_review.py（3者レビューCLI: Builder/Skeptic/User）を実装
 - [x] scripts/demo_business.py の単体実行導線を修正（sys.path 追加で ModuleNotFoundError を防止）
+- [x] P1: SECRET_KEYWORD の説明文脈を warn 化し、guard_text に検知サマリ（件数/種類/最初の位置）を追加
 
 ## How to run / test
 

--- a/idea_note.md
+++ b/idea_note.md
@@ -73,8 +73,10 @@
 - [ ] 具体的な小さな改善コード例（方針のみ）
 　- [x] (2026-03-14) Finding.severity をルールごとに設定可能にする（現在は固定）。
     - Notes: `aicw/safety.py` の `scan_privacy_risks()` / `guard_text()` に `severity_overrides` を追加し、ルールごとに `block/warn` 上書きを可能化。`tests/test_p0_privacy.py` に回帰テストを追加。
-　- SECRET_KEYWORD の検出は周辺語を確認して「単語単体の出現」だけでブロックしない（例: password が文脈で説明的に出ているだけなら warn）。
-　- ログ出力用に検出サマリを返す（件数、種類、最初の位置など）を guard_text に追加する。
+　- [x] (2026-03-14) SECRET_KEYWORD の検出は周辺語を確認して「単語単体の出現」だけでブロックしない（例: password が文脈で説明的に出ているだけなら warn）。
+    - Notes: `aicw/safety.py` に説明文脈ヒューリスティクスを追加し、`SECRET_KEYWORD` は `token:` / `password=` の実値提示でない説明用途では warn 扱い。
+　- [x] (2026-03-14) ログ出力用に検出サマリを返す（件数、種類、最初の位置など）を guard_text に追加する。
+    - Notes: `guard_text()` の返り値に `summary` を追加し、`aicw/decision.py` に `dlp_summary` を接続。`tests/test_p0_privacy.py` に回帰テストを追加。
 
 ---
 

--- a/progress_log.md
+++ b/progress_log.md
@@ -1,3 +1,34 @@
+## 2026-03-14 (session 20 — Privacyガードの文脈判定改善)
+
+### Goal
+- 次タスクとして idea_note の「具体的な小さな改善コード例（方針のみ）」を進める
+- SECRET_KEYWORD の説明用途誤検知を下げる
+- `guard_text()` に検出サマリを追加して運用観測性を上げる
+
+### Done
+- `aicw/safety.py`:
+  - `SECRET_KEYWORD` 向けに説明文脈ヒューリスティクスを追加
+  - `token:` / `password=` 形式の実値提示は block 維持
+  - `guard_text()` が `summary`（件数・種類・最初の位置）を返すよう拡張
+- `aicw/decision.py`:
+  - `guard_text()` の新戻り値に追従
+  - #6 blocked レスポンスと warning 付き OK レスポンスへ `dlp_summary` を接続
+- `tests/test_p0_privacy.py`:
+  - 説明用途の `SECRET_KEYWORD` が warn になる回帰テストを追加
+  - `guard_text()` の summary 構造を検証するテストを追加
+- `idea_note.md`:
+  - 「具体的な小さな改善コード例」の未完了2項目を done に更新
+
+### Test Results
+- `python -m unittest tests/test_p0_privacy.py -q` → **20 tests PASS**
+- `python -m unittest tests/test_meta_suggest.py tests/test_reverse_manipulation.py tests/test_api_contract.py tests/test_interactive_sim.py -q` → **75 tests PASS**
+
+### Next Actions（候補）
+- `guard_text()` summary の活用先を `audit_log` 系に拡張するか検討
+- Po_core 連携 API v1.0 の文書・契約差分の継続整備
+
+---
+
 # Progress Log
 > 各セッションの最後に追記（可能なら日付はJST、形式はYYYY-MM-DD）
 

--- a/tests/test_p0_privacy.py
+++ b/tests/test_p0_privacy.py
@@ -13,7 +13,7 @@ class TestP0Privacy(unittest.TestCase):
         # 文字列を分割して組み立てる（ソースに直接それっぽい形を残しにくくする）
         s = "x" + "@" + "y" + "." + "co"
         text = "contact: " + s
-        allowed, redacted, findings = guard_text(text)
+        allowed, redacted, findings, _summary = guard_text(text)
         self.assertFalse(allowed)
         self.assertNotIn("@", redacted)
         kinds = {f.kind for f in findings if f.severity == "block"}
@@ -22,7 +22,7 @@ class TestP0Privacy(unittest.TestCase):
     def test_blocks_phone_like(self):
         s = "0" + "0" + "-" + "0" + "0" + "-" + "0000"
         text = "phone: " + s
-        allowed, redacted, findings = guard_text(text)
+        allowed, redacted, findings, _summary = guard_text(text)
         self.assertFalse(allowed)
         kinds = {f.kind for f in findings if f.severity == "block"}
         self.assertIn("PHONE_LIKE", kinds)
@@ -30,7 +30,7 @@ class TestP0Privacy(unittest.TestCase):
     def test_blocks_secret_like_long(self):
         s = "A" * 40
         text = "maybe_secret: " + s
-        allowed, redacted, findings = guard_text(text)
+        allowed, redacted, findings, _summary = guard_text(text)
         self.assertFalse(allowed)
         kinds = {f.kind for f in findings if f.severity == "block"}
         self.assertIn("SECRET_LIKE_LONG", kinds)
@@ -39,7 +39,7 @@ class TestP0Privacy(unittest.TestCase):
         # POSTAL_CODE_LIKE は warn レベル（品番・識別コード等の誤検知があるため）
         s = "100" + "-" + "0001"
         text = "住所エリア: " + s
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         self.assertTrue(allowed, "POSTAL_CODE_LIKE は warn 化済みなのでブロックされない")
         warn_kinds = {f.kind for f in findings if f.severity == "warn"}
         block_kinds = {f.kind for f in findings if f.severity == "block"}
@@ -48,21 +48,38 @@ class TestP0Privacy(unittest.TestCase):
 
     def test_blocks_secret_keyword_token(self):
         text = "token: abc123"
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         self.assertFalse(allowed)
         kinds = {f.kind for f in findings if f.severity == "block"}
         self.assertIn("SECRET_KEYWORD", kinds)
 
     def test_blocks_secret_keyword_password(self):
         text = "password が必要です"
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         self.assertFalse(allowed)
         kinds = {f.kind for f in findings if f.severity == "block"}
         self.assertIn("SECRET_KEYWORD", kinds)
 
+    def test_secret_keyword_explanatory_context_warns(self):
+        text = "secret という単語は貼り付けないでください"
+        allowed, _redacted, findings, summary = guard_text(text)
+        self.assertTrue(allowed)
+        warn_kinds = {f.kind for f in findings if f.severity == "warn"}
+        self.assertIn("SECRET_KEYWORD", warn_kinds)
+        self.assertEqual(1, summary["warn_count"])
+
+    def test_guard_text_returns_summary(self):
+        text = "token: abc123 と 192.168.0.1"
+        allowed, _redacted, _findings, summary = guard_text(text)
+        self.assertFalse(allowed)
+        self.assertGreaterEqual(summary["total_findings"], 2)
+        self.assertGreaterEqual(summary["block_count"], 1)
+        self.assertIn("SECRET_KEYWORD", summary["kinds"])
+        self.assertIsNotNone(summary["first_block_start"])
+
     def test_override_secret_keyword_to_warn(self):
         text = "token: abc123"
-        allowed, _redacted, findings = guard_text(
+        allowed, _redacted, findings, _summary = guard_text(
             text,
             severity_overrides={"SECRET_KEYWORD": "warn"},
         )
@@ -72,7 +89,7 @@ class TestP0Privacy(unittest.TestCase):
 
     def test_override_ip_like_to_block(self):
         text = "server at 192.168.0.1"
-        allowed, _redacted, findings = guard_text(
+        allowed, _redacted, findings, _summary = guard_text(
             text,
             severity_overrides={"IP_LIKE": "block"},
         )
@@ -85,7 +102,7 @@ class TestP0Privacy(unittest.TestCase):
         email_part = "u" + "@" + "ex" + "." + "jp"
         phone_part = "03" + "-" + "1234" + "-" + "5678"
         text = "email: " + email_part + " tel: " + phone_part
-        allowed, redacted, findings = guard_text(text)
+        allowed, redacted, findings, _summary = guard_text(text)
         self.assertFalse(allowed)
         self.assertNotIn("@", redacted)
         block_kinds = {f.kind for f in findings if f.severity == "block"}
@@ -96,7 +113,7 @@ class TestP0Privacy(unittest.TestCase):
         # redacted テキストは元の機密値を含まないこと
         s = "A" * 36
         text = "key=" + s
-        _allowed, redacted, _findings = guard_text(text)
+        _allowed, redacted, _findings, _summary = guard_text(text)
         self.assertNotIn(s, redacted)
         self.assertIn("<REDACTED:", redacted)
 
@@ -108,7 +125,7 @@ class TestP0Privacy(unittest.TestCase):
         # IP_LIKE は warn レベル → allowed=True（ブロックしない）
         s = "192" + "." + "168" + "." + "0" + "." + "1"
         text = "server at " + s
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         self.assertTrue(allowed, "IP_LIKE は warn 化済みなのでブロックされない")
         warn_kinds = {f.kind for f in findings if f.severity == "warn"}
         block_kinds = {f.kind for f in findings if f.severity == "block"}
@@ -144,7 +161,7 @@ class TestP0Privacy(unittest.TestCase):
     def test_version_string_warns_not_blocks(self):
         # バージョン番号 1.2.3.4 は IP_LIKE に誤検知されるが、warn なのでブロックしない
         text = "version 1.2.3.4 を使用"
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         self.assertTrue(allowed, "バージョン文字列は warn 化済みでブロックされない")
         warn_kinds = {f.kind for f in findings if f.severity == "warn"}
         self.assertIn("IP_LIKE", warn_kinds)
@@ -155,14 +172,14 @@ class TestP0Privacy(unittest.TestCase):
 
     def test_allows_clean_text(self):
         text = "no sensitive patterns here"
-        allowed, redacted, findings = guard_text(text)
+        allowed, redacted, findings, _summary = guard_text(text)
         self.assertTrue(allowed)
         self.assertEqual(text, redacted)
         self.assertEqual([], findings)
 
     def test_allows_clean_japanese(self):
         text = "リリース日程を品質重視で決めたい。安全を最優先にする。"
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         self.assertTrue(allowed)
         self.assertEqual([], findings)
 
@@ -170,7 +187,7 @@ class TestP0Privacy(unittest.TestCase):
         # 31文字以下は SECRET_LIKE_LONG にひっかからない（境界値）
         s = "A" * 31
         text = "id: " + s
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         kinds = {f.kind for f in findings}
         self.assertNotIn("SECRET_LIKE_LONG", kinds)
 
@@ -183,7 +200,7 @@ class TestP0Privacy(unittest.TestCase):
         # P0 では安全側に倒すためブロック維持
         s = "A" * 32
         text = "value: " + s
-        allowed, _redacted, findings = guard_text(text)
+        allowed, _redacted, findings, _summary = guard_text(text)
         self.assertFalse(allowed, "既知の過検知: 32文字英数字はSECRET_LIKE_LONGに検知される（P0許容）")
         kinds = {f.kind for f in findings if f.severity == "block"}
         self.assertIn("SECRET_LIKE_LONG", kinds)


### PR DESCRIPTION
### Motivation
- Reduce false positives where `SECRET_KEYWORD` appears in explanatory/descriptive text while keeping explicit disclosures (e.g. `token:` / `password=`) blocked.
- Improve operational observability of DLP checks by returning a compact structured summary of detections for downstream tooling and reporting.

### Description
- Add a context heuristic `_is_secret_keyword_explanatory_context()` and apply it in `scan_privacy_risks()` so `SECRET_KEYWORD` is downgraded to `warn` when used in explanatory contexts unless explicitly presented as a value.
- Extend `guard_text()` to return a `summary` dict (`total_findings`, `block_count`, `warn_count`, `kinds`, `first_block_start`, `first_warn_start`) via a new helper `_build_guard_summary()` and adjust its return signature accordingly.
- Propagate the new guard return shape into the decision pipeline by updating `build_decision_report()` to consume the additional `dlp_summary` and include it in blocked responses and warning-bearing reports.
- Add regression tests and documentation updates: tests for explanatory `SECRET_KEYWORD` behavior and `guard_text()` summary (`tests/test_p0_privacy.py`), and update `idea_note.md`, `progress_log.md`, and `guideline.md` to reflect the change.

### Testing
- Ran `python -m unittest tests/test_p0_privacy.py -q` and all tests passed (`20 tests PASS`).
- Ran a selection of related suites `python -m unittest tests/test_meta_suggest.py tests/test_reverse_manipulation.py tests/test_api_contract.py tests/test_interactive_sim.py -q` and they passed (`75 tests PASS`).
- Ran the full test discovery `python -m unittest discover -s tests -q` and the suite passed locally (`643 tests PASS`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53b2ce198832891299366759ac171)